### PR TITLE
feat: use inset title bar style on macOS

### DIFF
--- a/src/main/mainWindow.ts
+++ b/src/main/mainWindow.ts
@@ -290,6 +290,7 @@ function createMainWindow() {
                   backgroundColor: "#ffffff00"
               }
             : {}),
+        ...(process.platform === "darwin" ? { titleBarStyle: "hiddenInset" } : {}),
         ...getWindowBoundsOptions()
     }));
     win.setMenuBarVisibility(false);

--- a/src/renderer/patches/index.ts
+++ b/src/renderer/patches/index.ts
@@ -6,3 +6,4 @@
 
 // TODO: Possibly auto generate glob if we have more patches in the future
 import "./spellCheck";
+import "./platformClass";

--- a/src/renderer/patches/platformClass.tsx
+++ b/src/renderer/patches/platformClass.tsx
@@ -1,0 +1,30 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0
+ * Vencord Desktop, a desktop app aiming to give you a snappier Discord Experience
+ * Copyright (c) 2023 Vendicated and Vencord contributors
+ */
+
+import { addPatch } from "./shared";
+
+addPatch({
+    patches: [
+        {
+            find: "platform-web",
+            replacement: {
+                // eslint-disable-next-line no-useless-escape
+                match: /return (?=__OVERLAY__\?""\.concat\((\i))/,
+                replace: "$1=$self.getPlatformClass(); return "
+            }
+        }
+    ],
+
+    getPlatformClass() {
+        const platform = navigator.platform.toLowerCase();
+
+        if (platform.includes("mac")) return "platform-osx";
+        if (platform.includes("win")) return "platform-win";
+        if (platform.includes("linux")) return "platform-linux";
+
+        return "platform-web";
+    }
+});

--- a/src/renderer/patches/platformClass.tsx
+++ b/src/renderer/patches/platformClass.tsx
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: GPL-3.0
- * Vencord Desktop, a desktop app aiming to give you a snappier Discord Experience
+ * Vesktop, a desktop app aiming to give you a snappier Discord Experience
  * Copyright (c) 2023 Vendicated and Vencord contributors
  */
 
@@ -12,19 +12,11 @@ addPatch({
             find: "platform-web",
             replacement: {
                 // eslint-disable-next-line no-useless-escape
-                match: /return (?=__OVERLAY__\?""\.concat\((\i))/,
-                replace: "$1=$self.getPlatformClass(); return "
+                match: /(?<=" platform-overlay"\):)\i/,
+                replace: "$self.getPlatformClass()"
             }
         }
     ],
 
-    getPlatformClass() {
-        const platform = navigator.platform.toLowerCase();
-
-        if (platform.includes("mac")) return "platform-osx";
-        if (platform.includes("win")) return "platform-win";
-        if (platform.includes("linux")) return "platform-linux";
-
-        return "platform-web";
-    }
+    getPlatformClass: () => (navigator.platform.toLowerCase().startsWith("mac") ? "platform-osx" : "platform-web")
 });


### PR DESCRIPTION
<table>
<tr>
 <td>Normal Discord</td>
 <td>Vencord Desktop</td>
 <td>This PR</td>
</tr>
<tr>
 <td><img src="https://github.com/Vencord/Desktop/assets/70191398/5bc15f08-9175-4627-a099-98fc3a6e4d9f"></td>
 <td><img src="https://github.com/Vencord/Desktop/assets/70191398/00100659-f538-47ec-a4ea-ae53cc88ff55"></td>
 <td><img src="https://github.com/Vencord/Desktop/assets/70191398/6b391d35-d73c-4c2a-bb4a-b5b95661583a"></td>
</tr>
</table>
