### PR TITLE
fix: remove duplicate quit items on macOS

### DIFF
--- a/src/main/mainWindow.ts
+++ b/src/main/mainWindow.ts
@@ -142,16 +142,15 @@ function initMenuBar(win: BrowserWindow) {
         {
             label: "Quit",
             accelerator: wantCtrlQ ? "CmdOrCtrl+Q" : void 0,
-            visible: !isWindows,
             role: "quit",
+            visible: !isWindows,
             click() {
                 app.quit();
             }
         },
-        {
+        isWindows && {
             label: "Quit",
-            accelerator: isWindows ? "Alt+F4" : void 0,
-            visible: isWindows,
+            accelerator: "Alt+F4",
             role: "quit",
             click() {
                 app.quit();

--- a/src/main/mainWindow.ts
+++ b/src/main/mainWindow.ts
@@ -142,8 +142,8 @@ function initMenuBar(win: BrowserWindow) {
         {
             label: "Quit",
             accelerator: wantCtrlQ ? "CmdOrCtrl+Q" : void 0,
-            role: "quit",
             visible: !isWindows,
+            role: "quit",
             click() {
                 app.quit();
             }


### PR DESCRIPTION
The visible property doesn't seem to work, the menu bar item still is shown on macOS