### PR TITLE
Remove macOS tray icon

### DIFF
--- a/src/main/mainWindow.ts
+++ b/src/main/mainWindow.ts
@@ -359,7 +359,7 @@ function createMainWindow() {
     if (Settings.store.staticTitle) win.on("page-title-updated", e => e.preventDefault());
 
     initWindowBoundsListeners(win);
-    if (Settings.store.tray ?? true) initTray(win);
+    if ((Settings.store.tray ?? true) && process.platform !== "darwin") initTray(win);
     initMenuBar(win);
     makeLinksOpenExternally(win);
     initSettingsListeners(win);


### PR DESCRIPTION
Even tho the tray icon is hilariously big (https://discord.com/channels/1015060230222131221/1026515880080842772/1133902408154624091), this PR removes the tray icon/functionality to stay consistent with the normal Discord client's behaviour.