### PR TITLE
Update Settings Text to Vesktop

### DIFF
--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -40,7 +40,7 @@ export default function SettingsUi() {
             "Open Links in app (experimental)",
             "Opens links in a new Vesktop window instead of your web browser"
         ],
-        ["staticTitle", "Static Title", 'Makes the window title "Vencord" instead of changing to the current page'],
+        ["staticTitle", "Static Title", 'Makes the window title "Vesktop" instead of changing to the current page'],
         ["enableMenu", "Enable Menu Bar", "Enables the application menu bar. Press ALT to toggle visibility."]
     ];
 


### PR DESCRIPTION
Fix Settings Text to say 'Vesktop' instead of 'Vencord', as per 87595deae749a856dccc115f7a3c32dd759ec537