### PR TITLE
feat: portable zip

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,8 @@
         "win": {
             "target": [
                 "nsis",
-                "portable"
+                "portable",
+                "zip"
             ]
         },
         "publish": {

--- a/package.json
+++ b/package.json
@@ -101,7 +101,6 @@
         "win": {
             "target": [
                 "nsis",
-                "portable",
                 "zip"
             ]
         },


### PR DESCRIPTION
some people don't want to use the nsis-based portable executable to run vesktop, so give them the option of using a zip-based version