### PR TITLE
ci: winget

### DIFF
--- a/.github/workflows/winget-submission.yml
+++ b/.github/workflows/winget-submission.yml
@@ -1,0 +1,27 @@
+name: Submit to Winget Community Repo
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  winget:
+    name: Publish winget package
+    runs-on: windows-latest
+    steps:
+      - name: Submit package to Winget Community Repo
+        run: |
+
+          $packageId = "Vencord.Vesktop"
+          $gitToken = "${{ secrets.WINGET_PAT }}"
+
+          # Fetching latest release from GitHub
+          $github = Invoke-RestMethod -uri "https://api.github.com/repos/vencord/vesktop/releases"
+          $targetRelease = $github | Select-Object -First 1
+          $installerUrl = $targetRelease | Select-Object -ExpandProperty assets -First 1 | Where-Object -Property name -match 'Vesktop-Setup.*?exe' | Select-Object -ExpandProperty browser_download_url
+          $packageVersion = $targetRelease.tag_name.Trim("v")
+
+          # Update package using wingetcreate
+          Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          .\wingetcreate.exe update $packageId --version $packageVersion --urls "$installerUrl" --submit --token $gitToken

--- a/.github/workflows/winget-submission.yml
+++ b/.github/workflows/winget-submission.yml
@@ -1,3 +1,8 @@
+# Based on Microsoft/DevHome Winget CI, modified for use in Vencord/Vesktop.
+#
+# Copyright (c) Microsoft Corporation and Contributors
+# Licensed under the MIT license.
+
 name: Submit to Winget Community Repo
 
 on:

--- a/.github/workflows/winget-submission.yml
+++ b/.github/workflows/winget-submission.yml
@@ -9,12 +9,13 @@ jobs:
   winget:
     name: Publish winget package
     runs-on: windows-latest
+    env:
+      WINGET_PAT: ${{ secrets.WINGET_PAT }}
     steps:
       - name: Submit package to Winget Community Repo
         run: |
 
           $packageId = "Vencord.Vesktop"
-          $gitToken = "${{ secrets.WINGET_PAT }}"
 
           # Fetching latest release from GitHub
           $github = Invoke-RestMethod -uri "https://api.github.com/repos/vencord/vesktop/releases"
@@ -24,4 +25,4 @@ jobs:
 
           # Update package using wingetcreate
           Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
-          .\wingetcreate.exe update $packageId --version $packageVersion --urls "$installerUrl" --submit --token $gitToken
+          .\wingetcreate.exe update $packageId --version $packageVersion --urls "$installerUrl" --submit --token $env:WINGET_PAT


### PR DESCRIPTION
Based off of Dev Home's Winget CI. `WINGET_PAT` will need to be set with the bot account PAT.

Supersedes and thus closes #98 and closes #100.