### PR TITLE
fix: add correct WMClass to desktop file

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
                 "GenericName": "Internet Messenger",
                 "Type": "Application",
                 "Categories": "Network;InstantMessaging;Chat;",
-                "Keywords": "discord;vencord;electron;chat;"
+                "Keywords": "discord;vencord;electron;chat;",
+                "WMClass": "VencordDesktop"
             }
         },
         "mac": {


### PR DESCRIPTION
It seems the WMClass on Linux still uses the old internal VencordDesktop name, so this PR adds the correct WMClass to the desktop file to resolve it.

Resolves #96.