### PR TITLE
hide audio sources with no name

### DIFF
--- a/src/main/virtmic.ts
+++ b/src/main/virtmic.ts
@@ -40,7 +40,8 @@ ipcMain.handle(IpcEvents.VIRT_MIC_LIST, () => {
     return obtainVenmic()
         ?.list()
         .filter(s => s["application.process.id"] !== audioPid)
-        .map(s => s["application.name"]);
+        .map(s => s["application.name"])
+        .filter(s => s);
 });
 
 ipcMain.handle(


### PR DESCRIPTION
since 0.4.0, multiple empty audio sources show up in the picker (on linux), see attached screenshot

![image](https://github.com/Vencord/Vesktop/assets/61147779/7c3083db-a833-4d17-9033-8c3a3d2bafbf)

this pr fixes it by checking if the strings are falsy, lmk if there is a better way do it