### PR TITLE
fix: make updater close button close updater

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -71,7 +71,7 @@ handle(IpcEvents.FOCUS, () => {
 });
 
 handle(IpcEvents.CLOSE, e => {
-    mainWin.close();
+    e.sender.close();
 });
 
 handle(IpcEvents.MINIMIZE, e => {


### PR DESCRIPTION
The updater close button currently closes the main window. This PR makes it actually close the updater.