### PR TITLE
feat: make updater window adapt to splash colors

### DIFF
--- a/src/main/splash.ts
+++ b/src/main/splash.ts
@@ -12,7 +12,7 @@ import { ICON_PATH, VIEW_DIR } from "shared/paths";
 import { Settings } from "./settings";
 
 export function patchVencordView(view: BrowserWindow) {
-    const { splashBackground, splashColor, splashTheming } = Settings.store;
+    const { splashBackground, splashColor, splashTheming, splashPositive, splashDanger } = Settings.store;
 
     if (splashTheming) {
         if (splashColor) {
@@ -24,6 +24,13 @@ export function patchVencordView(view: BrowserWindow) {
 
         if (splashBackground) {
             view.webContents.insertCSS(`body { --bg: ${splashBackground} !important }`);
+        }
+
+        if (splashPositive) {
+            view.webContents.insertCSS(`body { --button-positive-background: ${splashPositive} !important }`);
+        }
+        if (splashDanger) {
+            view.webContents.insertCSS(`body { --button-danger-background: ${splashDanger} !important }`);
         }
     }
 }

--- a/src/main/splash.ts
+++ b/src/main/splash.ts
@@ -11,6 +11,23 @@ import { ICON_PATH, VIEW_DIR } from "shared/paths";
 
 import { Settings } from "./settings";
 
+export function patchVencordView(view: BrowserWindow) {
+    const { splashBackground, splashColor, splashTheming } = Settings.store;
+
+    if (splashTheming) {
+        if (splashColor) {
+            const semiTransparentSplashColor = splashColor.replace("rgb(", "rgba(").replace(")", ", 0.2)");
+
+            view.webContents.insertCSS(`body { --fg: ${splashColor} !important }`);
+            view.webContents.insertCSS(`body { --fg-semi-trans: ${semiTransparentSplashColor} !important }`);
+        }
+
+        if (splashBackground) {
+            view.webContents.insertCSS(`body { --bg: ${splashBackground} !important }`);
+        }
+    }
+}
+
 export function createSplashWindow() {
     const splash = new BrowserWindow({
         ...SplashProps,
@@ -18,21 +35,7 @@ export function createSplashWindow() {
     });
 
     splash.loadFile(join(VIEW_DIR, "splash.html"));
-
-    const { splashBackground, splashColor, splashTheming } = Settings.store;
-
-    if (splashTheming) {
-        if (splashColor) {
-            const semiTransparentSplashColor = splashColor.replace("rgb(", "rgba(").replace(")", ", 0.2)");
-
-            splash.webContents.insertCSS(`body { --fg: ${splashColor} !important }`);
-            splash.webContents.insertCSS(`body { --fg-semi-trans: ${semiTransparentSplashColor} !important }`);
-        }
-
-        if (splashBackground) {
-            splash.webContents.insertCSS(`body { --bg: ${splashBackground} !important }`);
-        }
-    }
+    patchVencordView(splash);
 
     return splash;
 }

--- a/src/renderer/themedSplash.ts
+++ b/src/renderer/themedSplash.ts
@@ -27,6 +27,8 @@ const updateSplashColors = () => {
 
     const color = bodyStyles.get("--text-normal");
     const backgroundColor = bodyStyles.get("--background-primary");
+    const positive = bodyStyles.get("--button-positive-background");
+    const danger = bodyStyles.get("--button-danger-background");
 
     if (isValidColor(color)) {
         Settings.store.splashColor = resolveColor(color[0]);
@@ -34,6 +36,14 @@ const updateSplashColors = () => {
 
     if (isValidColor(backgroundColor)) {
         Settings.store.splashBackground = resolveColor(backgroundColor[0]);
+    }
+
+    if (isValidColor(positive)) {
+        Settings.store.splashPositive = resolveColor(positive[0]);
+    }
+
+    if (isValidColor(danger)) {
+        Settings.store.splashDanger = resolveColor(danger[0]);
     }
 };
 

--- a/src/shared/settings.d.ts
+++ b/src/shared/settings.d.ts
@@ -28,6 +28,9 @@ export interface Settings {
     firstLaunch?: boolean;
 
     splashTheming?: boolean;
+
     splashColor?: string;
     splashBackground?: string;
+    splashPositive?: string;
+    splashDanger?: string;
 }

--- a/src/updater/main.ts
+++ b/src/updater/main.ts
@@ -6,6 +6,7 @@
 
 import { app, BrowserWindow, shell } from "electron";
 import { Settings } from "main/settings";
+import { patchVencordView } from "main/splash";
 import { handle } from "main/utils/ipcWrappers";
 import { makeLinksOpenExternally } from "main/utils/makeLinksOpenExternally";
 import { githubGet, ReleaseData } from "main/utils/vencordLoader";
@@ -109,10 +110,12 @@ function openNewUpdateWindow() {
             contextIsolation: true,
             sandbox: true
         },
+        ...(process.platform === "darwin" ? { titleBarStyle: "hiddenInset" } : {}),
         icon: ICON_PATH
     });
 
     makeLinksOpenExternally(win);
+    patchVencordView(win);
 
     win.loadFile(join(VIEW_DIR, "updater.html"));
 }

--- a/static/views/updater.html
+++ b/static/views/updater.html
@@ -25,7 +25,7 @@
         button {
             cursor: pointer;
             padding: 0.5em;
-            color: var(--fg);
+            color: var(--bg);
             border: none;
             border-radius: 3px;
             font-weight: bold;
@@ -38,11 +38,11 @@
         }
 
         .green {
-            background-color: #248046;
+            background-color: var(--button-positive-background, #248046);
         }
 
         .red {
-            background-color: #ed4245;
+            background-color: var(--button-danger-background, #ed4245);
         }
     </style>
 </head>


### PR DESCRIPTION
A few things to consider:

- Should the splash colors setting be renamed if the updater also adapts to the theme?
- ~~Should the success/danger/link colors also be extracted from Discord web?~~ Implemented
