### PR TITLE
Fix : VM class for AppImage has broken Dekstop integrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
                 "Type": "Application",
                 "Categories": "Network;InstantMessaging;Chat;",
                 "Keywords": "discord;vencord;electron;chat;",
-                "WMClass": "VencordDesktop"
+                "WMClass": "VencordDesktop",
                 "StartupWMClass": "VencordDesktop"
             }
         },

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
                 "Categories": "Network;InstantMessaging;Chat;",
                 "Keywords": "discord;vencord;electron;chat;",
                 "WMClass": "VencordDesktop"
+                "StartupWMClass": "VencordDesktop"
             }
         },
         "mac": {


### PR DESCRIPTION

Hello, after installing Vencord Via AppImage, I've noticed that if I use a desktop integration tool, my VM doesn't put them in the same icon (so VMClass)
In the build section of the package.json I've added StartupVMClass as it's what's expected for most desktop environment (I didn't removed VMClass as I don't really know if its useful or not for other things.)

Also it's weird that there are two Icons shipped. like if the app image one has it's own bundled and the app another one. (It doesn't bother at all, but maybe it would be nice to choose what logo is the Icon)

But it's always cleaner to have it in the same VMClass for any desktop.

![Capture d’écran du 2023-10-23 13-45-36](https://github.com/Vencord/Vesktop/assets/52078885/7aa768bc-8542-492a-afb9-7a29f09a3e88)
![Capture d’écran du 2023-10-23 13-47-06](https://github.com/Vencord/Vesktop/assets/52078885/6ed531a4-a132-4790-a487-e9ad9baaecf1)

