### PR TITLE
fix positioning of traffic lights on darwin

### DIFF
--- a/src/main/mainWindow.ts
+++ b/src/main/mainWindow.ts
@@ -288,7 +288,8 @@ function getWindowBoundsOptions(): BrowserWindowConstructorOptions {
 
 function getDarwinOptions(): BrowserWindowConstructorOptions {
     const options = {
-        titleBarStyle: "hiddenInset"
+        titleBarStyle: "hidden",
+        trafficLightPosition: { x: 9, y: 9 },
     } as BrowserWindowConstructorOptions;
 
     const { splashTheming, splashBackground } = Settings.store;

--- a/src/main/mainWindow.ts
+++ b/src/main/mainWindow.ts
@@ -289,7 +289,7 @@ function getWindowBoundsOptions(): BrowserWindowConstructorOptions {
 function getDarwinOptions(): BrowserWindowConstructorOptions {
     const options = {
         titleBarStyle: "hidden",
-        trafficLightPosition: { x: 9, y: 9 },
+        trafficLightPosition: { x: 9, y: 9 }
     } as BrowserWindowConstructorOptions;
 
     const { splashTheming, splashBackground } = Settings.store;


### PR DESCRIPTION
Electron's default traffic light positioning is a bit offset compared to the official Discord desktop app on macOS. This fixes that offset issue.