### PR TITLE
Make linux display badges

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "homepage": "https://vencord.dev/",
     "license": "GPL-3.0",
     "author": "Vendicated <vendicated@riseup.net>",
+    "desktopName": "vencorddesktop.desktop",
     "main": "dist/js/main.js",
     "scripts": {
         "build": "tsx scripts/build/build.mts",


### PR DESCRIPTION
Add `desktopName` to package.json to make badge visible
https://github.com/signalapp/Signal-Desktop/issues/3387#issuecomment-500109546