### PR TITLE
refactor: introduce separate state settings

### DIFF
--- a/src/main/firstLaunch.ts
+++ b/src/main/firstLaunch.ts
@@ -14,7 +14,7 @@ import { ICON_PATH, VIEW_DIR } from "shared/paths";
 import { autoStart } from "./autoStart";
 import { DATA_DIR } from "./constants";
 import { createWindows } from "./mainWindow";
-import { Settings } from "./settings";
+import { Settings, State } from "./settings";
 import { makeLinksOpenExternally } from "./utils/makeLinksOpenExternally";
 
 interface Data {
@@ -46,7 +46,7 @@ export function createFirstLaunchTour() {
 
         Settings.store.minimizeToTray = data.minimizeToTray;
         Settings.store.discordBranch = data.discordBranch;
-        Settings.store.firstLaunch = false;
+        State.store.firstLaunch = false;
         Settings.store.arRPC = data.richPresence;
 
         if (data.autoStart) autoStart.enable();

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -14,7 +14,7 @@ import { createFirstLaunchTour } from "./firstLaunch";
 import { createWindows, mainWin } from "./mainWindow";
 import { registerMediaPermissionsHandler } from "./mediaPermissions";
 import { registerScreenShareHandler } from "./screenShare";
-import { Settings } from "./settings";
+import { State } from "./settings";
 
 if (IS_DEV) {
     require("source-map-support").install();
@@ -73,7 +73,7 @@ if (!app.requestSingleInstanceLock({ IS_DEV })) {
 }
 
 async function bootstrap() {
-    if (!Object.hasOwn(Settings.store, "firstLaunch")) {
+    if (!Object.hasOwn(State.store, "firstLaunch")) {
         createFirstLaunchTour();
     } else {
         createWindows();

--- a/src/main/mainWindow.ts
+++ b/src/main/mainWindow.ts
@@ -34,7 +34,7 @@ import {
     UserAgent,
     VENCORD_FILES_DIR
 } from "./constants";
-import { Settings, VencordSettings } from "./settings";
+import { Settings, State, VencordSettings } from "./settings";
 import { createSplashWindow } from "./splash";
 import { makeLinksOpenExternally } from "./utils/makeLinksOpenExternally";
 import { applyDeckKeyboardFix, askToApplySteamLayout, isDeckGameMode } from "./utils/steamOS";
@@ -268,7 +268,7 @@ function getWindowBoundsOptions(): BrowserWindowConstructorOptions {
     // We want the default window behaivour to apply in game mode since it expects everything to be fullscreen and maximized.
     if (isDeckGameMode) return {};
 
-    const { x, y, width, height } = Settings.store.windowBounds ?? {};
+    const { x, y, width, height } = State.store.windowBounds ?? {};
 
     const options = {
         width: width ?? DEFAULT_WIDTH,
@@ -313,8 +313,8 @@ function getDarwinOptions(): BrowserWindowConstructorOptions {
 
 function initWindowBoundsListeners(win: BrowserWindow) {
     const saveState = () => {
-        Settings.store.maximized = win.isMaximized();
-        Settings.store.minimized = win.isMinimized();
+        State.store.maximized = win.isMaximized();
+        State.store.minimized = win.isMinimized();
     };
 
     win.on("maximize", saveState);
@@ -322,7 +322,7 @@ function initWindowBoundsListeners(win: BrowserWindow) {
     win.on("unmaximize", saveState);
 
     const saveBounds = () => {
-        Settings.store.windowBounds = win.getBounds();
+        State.store.windowBounds = win.getBounds();
     };
 
     win.on("resize", saveBounds);
@@ -454,7 +454,7 @@ export async function createWindows() {
         splash.destroy();
         mainWin!.show();
 
-        if (Settings.store.maximized && !isDeckGameMode) {
+        if (State.store.maximized && !isDeckGameMode) {
             mainWin!.maximize();
         }
 

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -6,21 +6,22 @@
 
 import { mkdirSync, readFileSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
-import type { Settings as TSettings } from "shared/settings";
+import type { Settings as TSettings, State as TState } from "shared/settings";
 import { SettingsStore } from "shared/utils/SettingsStore";
 
 import { DATA_DIR, VENCORD_SETTINGS_FILE } from "./constants";
 
 const SETTINGS_FILE = join(DATA_DIR, "settings.json");
+const STATE_FILE = join(DATA_DIR, "state.json");
 
-function loadSettings<T extends object = any>(file: string, name: string) {
+function loadSettings<T extends object = any>(file: string, description: string) {
     let settings = {} as T;
     try {
         const content = readFileSync(file, "utf8");
         try {
             settings = JSON.parse(content);
         } catch (err) {
-            console.error(`Failed to parse ${name} settings.json:`, err);
+            console.error(`Failed to parse ${description}:`, err);
         }
     } catch {}
 
@@ -33,5 +34,6 @@ function loadSettings<T extends object = any>(file: string, name: string) {
     return store;
 }
 
-export const Settings = loadSettings<TSettings>(SETTINGS_FILE, "Vesktop");
-export const VencordSettings = loadSettings<any>(VENCORD_SETTINGS_FILE, "Vencord");
+export const Settings = loadSettings<TSettings>(SETTINGS_FILE, "Vesktop settings.json");
+export const State = loadSettings<TState>(STATE_FILE, "Vesktop state.json");
+export const VencordSettings = loadSettings<any>(VENCORD_SETTINGS_FILE, "Vencord settings.json");

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -30,7 +30,11 @@ function createSettingsStore<T extends object = any>(file: string, settings: T) 
     const store = new SettingsStore(settings);
     store.addGlobalChangeListener(o => {
         mkdirSync(dirname(file), { recursive: true });
-        writeFileSync(file, JSON.stringify(o, null, 4));
+        try {
+            writeFileSync(file, JSON.stringify(o, null, 4));
+        } catch (err) {
+            console.error(`Failed to save ${file}`, err);
+        }
     });
 
     return store;

--- a/src/main/utils/steamOS.ts
+++ b/src/main/utils/steamOS.ts
@@ -10,7 +10,7 @@ import { sleep } from "shared/utils/sleep";
 import { promisify } from "util";
 
 import { MessageBoxChoice } from "../constants";
-import { Settings } from "../settings";
+import { State } from "../settings";
 
 const exec = promisify(callbackExec);
 
@@ -57,8 +57,8 @@ async function showLayout(appId: string) {
 export async function askToApplySteamLayout(win: BrowserWindow) {
     const appId = getAppId();
     if (!appId) return;
-    if (Settings.store.steamOSLayoutVersion === layoutVersion) return;
-    const update = Boolean(Settings.store.steamOSLayoutVersion);
+    if (State.store.steamOSLayoutVersion === layoutVersion) return;
+    const update = Boolean(State.store.steamOSLayoutVersion);
 
     // Touch screen breaks in some menus when native touch mode is enabled on latest SteamOS beta, remove most of the update specific text once that's fixed.
     const { response } = await dialog.showMessageBox(win, {
@@ -74,8 +74,8 @@ ${update ? "Click" : "Tap"} no to keep your current layout.`,
         type: "question"
     });
 
-    if (Settings.store.steamOSLayoutVersion !== layoutVersion) {
-        Settings.store.steamOSLayoutVersion = layoutVersion;
+    if (State.store.steamOSLayoutVersion !== layoutVersion) {
+        State.store.steamOSLayoutVersion = layoutVersion;
     }
 
     if (response === MessageBoxChoice.Cancel) return;

--- a/src/shared/settings.d.ts
+++ b/src/shared/settings.d.ts
@@ -18,19 +18,22 @@ export interface Settings {
     arRPC?: boolean;
     appBadge?: boolean;
     discordWindowsTitleBar?: boolean;
-
-    maximized?: boolean;
-    minimized?: boolean;
-    windowBounds?: Rectangle;
     disableMinSize?: boolean;
 
     checkUpdates?: boolean;
-    skippedUpdate?: string;
-    firstLaunch?: boolean;
 
     splashTheming?: boolean;
     splashColor?: string;
     splashBackground?: string;
+}
+
+export interface State {
+    maximized?: boolean;
+    minimized?: boolean;
+    windowBounds?: Rectangle;
+
+    skippedUpdate?: string;
+    firstLaunch?: boolean;
 
     steamOSLayoutVersion?: number;
 }

--- a/src/shared/settings.d.ts
+++ b/src/shared/settings.d.ts
@@ -6,7 +6,8 @@
 
 import type { Rectangle } from "electron";
 
-export interface Settings {
+export interface SettingsV1 {
+    formatVersion: 1;
     discordBranch?: "stable" | "canary" | "ptb";
     vencordDir?: string;
     transparencyOption?: "none" | "mica" | "tabbed" | "acrylic";
@@ -27,7 +28,8 @@ export interface Settings {
     splashBackground?: string;
 }
 
-export interface State {
+export interface StateV1 {
+    formatVersion: 1;
     maximized?: boolean;
     minimized?: boolean;
     windowBounds?: Rectangle;

--- a/src/updater/main.ts
+++ b/src/updater/main.ts
@@ -5,7 +5,7 @@
  */
 
 import { app, BrowserWindow, shell } from "electron";
-import { Settings } from "main/settings";
+import { Settings, State } from "main/settings";
 import { handle } from "main/utils/ipcWrappers";
 import { makeLinksOpenExternally } from "main/utils/makeLinksOpenExternally";
 import { githubGet, ReleaseData } from "main/utils/vencordLoader";
@@ -52,7 +52,7 @@ handle(IpcEvents.UPDATER_DOWNLOAD, () => {
 });
 
 handle(IpcEvents.UPDATE_IGNORE, () => {
-    Settings.store.skippedUpdate = updateData.latestVersion;
+    State.store.skippedUpdate = updateData.latestVersion;
 });
 
 function isOutdated(oldVersion: string, newVersion: string) {
@@ -91,7 +91,7 @@ export async function checkUpdates() {
             release: data
         };
 
-        if (Settings.store.skippedUpdate !== newVersion && isOutdated(oldVersion, newVersion)) {
+        if (State.store.skippedUpdate !== newVersion && isOutdated(oldVersion, newVersion)) {
             openNewUpdateWindow();
         }
     } catch (e) {


### PR DESCRIPTION
Related: #220

# TODOs
- [ ] Only take actual props when migrating from legacy settings

