### PR TITLE
fix crash on shitvidia when running under wayland

### DIFF
--- a/src/main/mainWindow.ts
+++ b/src/main/mainWindow.ts
@@ -452,6 +452,9 @@ export async function createWindows() {
 
     mainWin.webContents.on("did-finish-load", () => {
         splash.destroy();
+        // Doing this works around the gpu process crash when showing a hidden window on wayland with nvidia
+        mainWin!.show();
+        mainWin!.hide();
         mainWin!.show();
 
         if (Settings.store.maximized && !isDeckGameMode) {

--- a/src/main/mainWindow.ts
+++ b/src/main/mainWindow.ts
@@ -453,12 +453,13 @@ export async function createWindows() {
 
     mainWin.webContents.on("did-finish-load", () => {
         splash.destroy();
-        // Doing this works around the gpu process crash when showing a hidden window on wayland with nvidia
-        mainWin!.show();
-        mainWin!.hide();
-        mainWin!.show();
 
-        if (!startMinimized || isDeckGameMode) mainWin!.show();
+        if (!startMinimized || isDeckGameMode) {
+            // Doing this works around the gpu process crash when showing a hidden window on wayland with nvidia
+            mainWin!.show();
+            mainWin!.hide();
+            mainWin!.show();
+        }
 
         if (isDeckGameMode) {
             // always use entire display


### PR DESCRIPTION
works around this issue
```
[23720:1113/145745.110129:ERROR:gbm_wrapper.cc(253)] Failed to export buffer to dma_buf: No such file or directory (2)
[23720:1113/145745.110235:ERROR:gbm_pixmap_wayland.cc(82)] Cannot create bo with format= RGBA_8888 and usage=SCANOUT
[23720:1113/145745.110468:ERROR:gbm_wrapper.cc(253)] Failed to export buffer to dma_buf: No such file or directory (2)
[23720:1113/145745.110530:ERROR:gbm_pixmap_wayland.cc(82)] Cannot create bo with format= RGBA_8888 and usage=GPU_READ
```
when using meme gpus and `--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations`

no idea why this works lmao

![Screenshot from 2023-11-13 14-55-59](https://github.com/Vencord/Vesktop/assets/42613600/f799c096-e3bb-4656-b50e-23fc18d6ece3)
