### PR TITLE
Disables always on top on updater window

### DIFF
--- a/src/shared/browserWinProperties.ts
+++ b/src/shared/browserWinProperties.ts
@@ -13,6 +13,5 @@ export const SplashProps: BrowserWindowConstructorOptions = {
     width: 300,
     center: true,
     resizable: false,
-    maximizable: false,
-    alwaysOnTop: true
+    maximizable: false
 };

--- a/src/updater/main.ts
+++ b/src/updater/main.ts
@@ -103,7 +103,6 @@ function openNewUpdateWindow() {
     const win = new BrowserWindow({
         width: 500,
         autoHideMenuBar: true,
-        alwaysOnTop: true,
         webPreferences: {
             preload: join(__dirname, "updaterPreload.js"),
             nodeIntegration: false,


### PR DESCRIPTION
Always on top makes it impossible to minimize it, rendering the desktop space unusable.