### PR TITLE
Tray: hide window if tray clicked while window focused

### DIFF
--- a/src/main/mainWindow.ts
+++ b/src/main/mainWindow.ts
@@ -121,7 +121,13 @@ function initTray(win: BrowserWindow) {
     tray = new Tray(ICON_PATH);
     tray.setToolTip("Vesktop");
     tray.setContextMenu(trayMenu);
-    tray.on("click", () => win.show());
+    tray.on("click", () => {
+        if (win.isFocused()) {
+            win.hide();
+        } else {
+            win.show();
+        }
+    });
 
     win.on("show", () => {
         trayMenu.items[0].enabled = false;

--- a/src/main/mainWindow.ts
+++ b/src/main/mainWindow.ts
@@ -126,6 +126,7 @@ function initTray(win: BrowserWindow) {
             win.hide();
         } else {
             win.show();
+            win.focus();
         }
     });
 


### PR DESCRIPTION
Small quality-of-life thing. Allows the user to peek at Discord via the tray without moving the mouse from the tray to the window decoration or Alt-F4ing.

Can move to a setting if this is undesirable for some users.