### PR TITLE
SteamOS: add flatpak support using steam.pipe

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -21,6 +21,7 @@ import { VENCORD_FILES_DIR, VENCORD_QUICKCSS_FILE, VENCORD_THEMES_DIR } from "./
 import { mainWin } from "./mainWindow";
 import { Settings } from "./settings";
 import { handle, handleSync } from "./utils/ipcWrappers";
+import { isDeckGameMode, showGamePage } from "./utils/steamOS";
 import { isValidVencordInstall } from "./utils/vencordLoader";
 
 handleSync(IpcEvents.GET_VENCORD_PRELOAD_FILE, () => join(VENCORD_FILES_DIR, "vencordDesktopPreload.js"));
@@ -47,11 +48,14 @@ handle(IpcEvents.SET_SETTINGS, (_, settings: typeof Settings.store, path?: strin
     Settings.setData(settings, path);
 });
 
-handle(IpcEvents.RELAUNCH, () => {
+handle(IpcEvents.RELAUNCH, async () => {
     const options: RelaunchOptions = {
         args: process.argv.slice(1).concat(["--relaunch"])
     };
-    if (app.isPackaged && process.env.APPIMAGE) {
+    if (isDeckGameMode) {
+        // We can't properly relaunch when running under gamescope, but we can at least navigate to our page in Steam.
+        await showGamePage();
+    } else if (app.isPackaged && process.env.APPIMAGE) {
         execFile(process.env.APPIMAGE, options.args);
     } else {
         app.relaunch(options);

--- a/src/main/utils/makeLinksOpenExternally.ts
+++ b/src/main/utils/makeLinksOpenExternally.ts
@@ -7,6 +7,7 @@
 import { BrowserWindow, shell } from "electron";
 
 import { Settings } from "../settings";
+import { execSteamURL, isDeckGameMode, openURL } from "./steamOS";
 
 export function makeLinksOpenExternally(win: BrowserWindow) {
     win.webContents.setWindowOpenHandler(({ url }) => {
@@ -30,9 +31,20 @@ export function makeLinksOpenExternally(win: BrowserWindow) {
                 }
             // eslint-disable-next-line no-fallthrough
             case "mailto:":
-            case "steam:":
             case "spotify:":
-                shell.openExternal(url);
+                if (isDeckGameMode) {
+                    openURL(url);
+                } else {
+                    shell.openExternal(url);
+                }
+                break;
+            case "steam:":
+                if (isDeckGameMode) {
+                    execSteamURL(url);
+                } else {
+                    shell.openExternal(url);
+                }
+                break;
         }
 
         return { action: "deny" };

--- a/src/main/utils/makeLinksOpenExternally.ts
+++ b/src/main/utils/makeLinksOpenExternally.ts
@@ -7,7 +7,7 @@
 import { BrowserWindow, shell } from "electron";
 
 import { Settings } from "../settings";
-import { execSteamURL, isDeckGameMode, openURL } from "./steamOS";
+import { execSteamURL, isDeckGameMode, steamOpenURL } from "./steamOS";
 
 export function makeLinksOpenExternally(win: BrowserWindow) {
     win.webContents.setWindowOpenHandler(({ url }) => {
@@ -33,7 +33,7 @@ export function makeLinksOpenExternally(win: BrowserWindow) {
             case "mailto:":
             case "spotify:":
                 if (isDeckGameMode) {
-                    openURL(url);
+                    steamOpenURL(url);
                 } else {
                     shell.openExternal(url);
                 }

--- a/src/main/utils/steamOS.ts
+++ b/src/main/utils/steamOS.ts
@@ -49,7 +49,7 @@ export async function execSteamURL(url: string): Promise<void> {
     );
 }
 
-export async function openURL(url: string) {
+export async function steamOpenURL(url: string) {
     await execSteamURL(`steam://openurl/${url}`);
 }
 

--- a/src/main/utils/steamOS.ts
+++ b/src/main/utils/steamOS.ts
@@ -4,15 +4,12 @@
  * Copyright (c) 2023 Vendicated and Vencord contributors
  */
 
-import { exec as callbackExec } from "child_process";
 import { BrowserWindow, dialog } from "electron";
-import { sleep } from "shared/utils/sleep";
-import { promisify } from "util";
+import { writeFile } from "fs/promises";
+import { join } from "path";
 
 import { MessageBoxChoice } from "../constants";
 import { Settings } from "../settings";
-
-const exec = promisify(callbackExec);
 
 // Bump this to re-show the prompt
 const layoutVersion = 2;
@@ -42,16 +39,28 @@ function getAppId(): string | null {
     return null;
 }
 
-async function execSteamURL(url: string): Promise<void> {
-    await exec(`steam -ifrunning ${url}`);
+export async function execSteamURL(url: string): Promise<void> {
+    // This doesn't allow arbitrary execution despite the weird syntax.
+    await writeFile(
+        join(process.env.HOME || "/home/deck", ".steam", "steam.pipe"),
+        // replace ' to prevent argument injection
+        `'${process.env.HOME}/.local/share/Steam/ubuntu12_32/steam' '-ifrunning' '${url.replaceAll("'", "%27")}'\n`,
+        "utf-8"
+    );
+}
+
+export async function openURL(url: string) {
+    await execSteamURL(`steam://openurl/${url}`);
+}
+
+export async function showGamePage() {
+    const appId = getAppId();
+    if (!appId) return;
+    await execSteamURL(`steam://nav/games/details/${appId}`);
 }
 
 async function showLayout(appId: string) {
-    await execSteamURL(`steam://controllerconfig/${appId}/${layoutId}`);
-    // because the UI doesn't consistently reload after the data for the config has loaded...
-    // HOW HAS NOBODY AT VALVE RUN INTO THIS YET
-    await sleep(100);
-    await execSteamURL(`steam://controllerconfig/${appId}/${layoutId}`);
+    execSteamURL(`steam://controllerconfig/${appId}/${layoutId}`);
 }
 
 export async function askToApplySteamLayout(win: BrowserWindow) {


### PR DESCRIPTION
needs `--filesystem=~/.steam` on the flatpak side

- Refactors SteamOS support to use steam.pipe instead
- Adds support for opening URLs in the steam browser in game mode
- Opens the Vesktop app page in steam instead of attempting to restart Vesktop in game mode (which won't work)