### PR TITLE
[fix] Update electron to 28.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "@typescript-eslint/parser": "^6.13.1",
         "@vencord/types": "^0.1.2",
         "dotenv": "^16.3.1",
-        "electron": "^27.1.2",
+        "electron": "^28.1.0",
         "electron-builder": "^24.9.1",
         "esbuild": "^0.19.8",
         "eslint": "^8.54.0",


### PR DESCRIPTION
Updates electron, which now uses chrome 120
  - ^119 is now required for colonist due to document.hasStorageAccess()