### PR TITLE
SteamOS: always use dark theme

### DIFF
--- a/src/main/mainWindow.ts
+++ b/src/main/mainWindow.ts
@@ -442,6 +442,11 @@ function createMainWindow() {
 const runVencordMain = once(() => require(join(VENCORD_FILES_DIR, "vencordDesktopMain.js")));
 
 export async function createWindows() {
+    if (isDeckGameMode) {
+        // In the Flatpak on SteamOS the theme is detected as light, but SteamOS only has a dark mode, so we just override it
+        nativeTheme.themeSource = "dark";
+    }
+
     const { startMinimized } = Settings.store;
     const splash = createSplashWindow(startMinimized);
     // SteamOS letterboxes and scales it terribly, so just full screen it


### PR DESCRIPTION
The Flatpak always detects light theme, but SteamOS only has a dark mode so we can just always use dark mode there.

To the 1 person using a light theme with decky: you are insane go explode.