### PR TITLE
feat: Add start minimized as a launch argument

### DIFF
--- a/src/main/mainWindow.ts
+++ b/src/main/mainWindow.ts
@@ -458,7 +458,7 @@ export async function createWindows() {
     mainWin.webContents.on("did-finish-load", () => {
         splash.destroy();
 
-        if (!startMinimized || isDeckGameMode) mainWin!.show();
+        if (!startMinimized) mainWin!.show();
 
         if (isDeckGameMode) {
             // always use entire display

--- a/src/main/mainWindow.ts
+++ b/src/main/mainWindow.ts
@@ -458,9 +458,9 @@ export async function createWindows() {
     mainWin.webContents.on("did-finish-load", () => {
         splash.destroy();
 
-        if (!startMinimized) mainWin!.show();
-        else if (State.store.maximized && !isDeckGameMode) {
-            mainWin!.maximize();
+        if (!startMinimized) {
+            mainWin!.show();
+            if (State.store.maximized && !isDeckGameMode) mainWin!.maximize();
         }
 
         if (isDeckGameMode) {

--- a/src/main/mainWindow.ts
+++ b/src/main/mainWindow.ts
@@ -458,9 +458,7 @@ export async function createWindows() {
     mainWin.webContents.on("did-finish-load", () => {
         splash.destroy();
 
-        if (State.store.maximized && !isDeckGameMode) {
-            mainWin!.maximize();
-        }
+        if (!startMinimized || isDeckGameMode) mainWin!.show();
 
         if (isDeckGameMode) {
             // always use entire display

--- a/src/main/mainWindow.ts
+++ b/src/main/mainWindow.ts
@@ -459,6 +459,9 @@ export async function createWindows() {
         splash.destroy();
 
         if (!startMinimized) mainWin!.show();
+        else if (State.store.maximized && !isDeckGameMode) {
+            mainWin!.maximize();
+        }
 
         if (isDeckGameMode) {
             // always use entire display

--- a/src/main/splash.ts
+++ b/src/main/splash.ts
@@ -11,10 +11,11 @@ import { ICON_PATH, VIEW_DIR } from "shared/paths";
 
 import { Settings } from "./settings";
 
-export function createSplashWindow() {
+export function createSplashWindow(startMinimized = false) {
     const splash = new BrowserWindow({
         ...SplashProps,
-        icon: ICON_PATH
+        icon: ICON_PATH,
+        show: !startMinimized
     });
 
     splash.loadFile(join(VIEW_DIR, "splash.html"));


### PR DESCRIPTION
Reimplements #248 to allow starting Vencord minimized/hidden, but with an argument instead of a Settings toggle, so that it may be appended to autostart shortcuts without impacting explicit launching of the app.

Flag is `--start-minimized` to match the official Discord application's flag.