### PR TITLE
Add an option to disable the splash animation

### DIFF
--- a/src/main/splash.ts
+++ b/src/main/splash.ts
@@ -20,7 +20,7 @@ export function createSplashWindow(startMinimized = false) {
 
     splash.loadFile(join(VIEW_DIR, "splash.html"));
 
-    const { splashBackground, splashColor, splashTheming } = Settings.store;
+    const { splashBackground, splashColor, splashTheming, disableSplashAnimation } = Settings.store;
 
     if (splashTheming) {
         if (splashColor) {
@@ -33,6 +33,10 @@ export function createSplashWindow(startMinimized = false) {
         if (splashBackground) {
             splash.webContents.insertCSS(`body { --bg: ${splashBackground} !important }`);
         }
+    }
+
+    if (!disableSplashAnimation) {
+        splash.webContents.insertCSS(`img {display: block !important}`);
     }
 
     return splash;

--- a/src/main/splash.ts
+++ b/src/main/splash.ts
@@ -12,6 +12,11 @@ import { ICON_PATH, VIEW_DIR } from "shared/paths";
 import { Settings } from "./settings";
 
 export function createSplashWindow(startMinimized = false) {
+    const { splashBackground, splashColor, splashTheming, disableSplashAnimation } = Settings.store;
+
+    if (disableSplashAnimation) {
+        SplashProps.height = 150;
+    }
     const splash = new BrowserWindow({
         ...SplashProps,
         icon: ICON_PATH,
@@ -19,8 +24,6 @@ export function createSplashWindow(startMinimized = false) {
     });
 
     splash.loadFile(join(VIEW_DIR, "splash.html"));
-
-    const { splashBackground, splashColor, splashTheming, disableSplashAnimation } = Settings.store;
 
     if (splashTheming) {
         if (splashColor) {

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -49,6 +49,7 @@ export default function SettingsUi() {
         ["disableSmoothScroll", "Disable smooth scrolling", "Disables smooth scrolling in Vesktop", false],
         ["hardwareAcceleration", "Hardware Acceleration", "Enable hardware acceleration", true],
         ["splashTheming", "Splash theming", "Adapt the splash window colors to your custom theme", false],
+        ["disableSplashAnimation", "Disable splash animation", "Disable the animation on the splash window", false],
         [
             "openLinksWithElectron",
             "Open Links in app (experimental)",

--- a/src/shared/settings.d.ts
+++ b/src/shared/settings.d.ts
@@ -28,6 +28,7 @@ export interface Settings {
     checkUpdates?: boolean;
 
     splashTheming?: boolean;
+    disableSplashAnimation?: boolean;
     splashColor?: string;
     splashBackground?: string;
 }

--- a/static/views/splash.html
+++ b/static/views/splash.html
@@ -26,18 +26,14 @@
             width: 128px;
             height: 128px;
             image-rendering: pixelated;
+            display: none;
         }
     </style>
 </head>
 
 <body>
     <div class="wrapper">
-        <img
-            draggable="false"
-            src="../shiggy.gif"
-            alt="shiggy"
-            role="presentation"
-        />
+        <img draggable="false" src="../shiggy.gif" alt="shiggy" role="presentation" />
         <p>Loading Vesktop...</p>
     </div>
 </body>


### PR DESCRIPTION
This PR adds a settings option to prevent the `shiggy.gif` image from being shown on the splash screen. This setting is off by default, so it shouldn't affect any existing behavior.

![image](https://github.com/Vencord/Vesktop/assets/71154407/848a6d6b-92d0-49a9-ab60-b874b3180464)

When this setting is enabled, the splash screen instead looks like this:
![image](https://github.com/Vencord/Vesktop/assets/71154407/67e6ecd3-7d06-4077-a2be-00749d519146)


This PR would partially solve #352.