### PR TITLE
fix: transform patches `find` to array

### DIFF
--- a/src/renderer/patches/shared.ts
+++ b/src/renderer/patches/shared.ts
@@ -17,6 +17,7 @@ export function addPatch<P extends PatchData>(p: P) {
     const { patches, ...globals } = p;
 
     for (const patch of patches as Patch[]) {
+        if (!Array.isArray(patch.find)) patch.find = [patch.find];
         if (!Array.isArray(patch.replacement)) patch.replacement = [patch.replacement];
         for (const r of patch.replacement) {
             if (typeof r.replace === "string") r.replace = r.replace.replaceAll("$self", "VCDP");


### PR DESCRIPTION
The latest dev build of Vencord expects it to be an array