### PR TITLE
Allow users to pass --enable/disable-features flag

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -27,10 +27,12 @@ process.env.VENCORD_USER_DATA_DIR = DATA_DIR;
 function init() {
     const { disableSmoothScroll, hardwareAcceleration } = Settings.store;
 
+    const enableFeatures: string[] = [];
+
     if (hardwareAcceleration === false) {
         app.disableHardwareAcceleration();
     } else {
-        app.commandLine.appendSwitch("enable-features", "VaapiVideoDecodeLinuxGL,VaapiVideoEncoder,VaapiVideoDecoder");
+        enableFeatures.push("VaapiVideoDecodeLinuxGL", "VaapiVideoEncoder", "VaapiVideoDecoder");
     }
 
     if (disableSmoothScroll) {
@@ -47,6 +49,11 @@ function init() {
         "disable-features",
         "WinRetrieveSuggestionsOnlyOnDemand,HardwareMediaKeyHandling,MediaSessionService,WidgetLayering"
     );
+
+    // don't overwrite command-line supplied switches
+    if (!app.commandLine.hasSwitch("enable-features")) {
+        app.commandLine.appendSwitch("enable-features", enableFeatures.join(","));
+    }
 
     // In the Flatpak on SteamOS the theme is detected as light, but SteamOS only has a dark mode, so we just override it
     if (isDeckGameMode) nativeTheme.themeSource = "dark";

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -27,12 +27,13 @@ process.env.VENCORD_USER_DATA_DIR = DATA_DIR;
 function init() {
     const { disableSmoothScroll, hardwareAcceleration } = Settings.store;
 
-    const enableFeatures: string[] = [];
+    const enabledFeatures = app.commandLine.getSwitchValue("enable-features").split(",");
+    const disabledFeatures = app.commandLine.getSwitchValue("disable-features").split(",");
 
     if (hardwareAcceleration === false) {
         app.disableHardwareAcceleration();
     } else {
-        enableFeatures.push("VaapiVideoDecodeLinuxGL", "VaapiVideoEncoder", "VaapiVideoDecoder");
+        enabledFeatures.push("VaapiVideoDecodeLinuxGL", "VaapiVideoEncoder", "VaapiVideoDecoder");
     }
 
     if (disableSmoothScroll) {
@@ -45,15 +46,15 @@ function init() {
     // HardwareMediaKeyHandling,MediaSessionService: Prevent Discord from registering as a media service.
     //
     // WidgetLayering (Vencord Added): Fix DevTools context menus https://github.com/electron/electron/issues/38790
-    app.commandLine.appendSwitch(
-        "disable-features",
-        "WinRetrieveSuggestionsOnlyOnDemand,HardwareMediaKeyHandling,MediaSessionService,WidgetLayering"
+    disabledFeatures.push(
+        "WinRetrieveSuggestionsOnlyOnDemand",
+        "HardwareMediaKeyHandling",
+        "MediaSessionService",
+        "WidgetLayering"
     );
 
-    // don't overwrite command-line supplied switches
-    if (!app.commandLine.hasSwitch("enable-features")) {
-        app.commandLine.appendSwitch("enable-features", enableFeatures.join(","));
-    }
+    app.commandLine.appendSwitch("enable-features", [...new Set(enabledFeatures)].filter(Boolean).join(","));
+    app.commandLine.appendSwitch("disable-features", [...new Set(disabledFeatures)].filter(Boolean).join(","));
 
     // In the Flatpak on SteamOS the theme is detected as light, but SteamOS only has a dark mode, so we just override it
     if (isDeckGameMode) nativeTheme.themeSource = "dark";


### PR DESCRIPTION
This PR implements the solution in #526.

I am also looking to adding the flags to Vesktop, unfortunately it is impossible to set the argument in time as `app.getGPUInfo()` is async and I don't know if Electron has already initialized the GUI backend by then. It might be worth looking into as a toggle in the settings (probably something like "Experimental Video Decode Acceleration on AMD" but this is so specific it's hard to come out with a suitable name).