### PR TITLE
fix regression breaking venmic

### DIFF
--- a/src/renderer/patches/hideVenmicInput.tsx
+++ b/src/renderer/patches/hideVenmicInput.tsx
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0
+ * Vesktop, a desktop app aiming to give you a snappier Discord Experience
+ * Copyright (c) 2023 Vendicated and Vencord contributors
+ */
+
+import { addPatch } from "./shared";
+
+addPatch({
+    patches: [
+        {
+            find: 'setSinkId"in',
+            replacement: {
+                // eslint-disable-next-line no-useless-escape
+                match: /return (\i)\?navigator\.mediaDevices\.enumerateDevices/,
+                replace: "return $1 ? $self.filteredDevices"
+            }
+        }
+    ],
+
+    async filteredDevices() {
+        const original = await navigator.mediaDevices.enumerateDevices();
+        return original.filter(x => x.label !== "vencord-screen-share");
+    }
+});

--- a/src/renderer/patches/index.ts
+++ b/src/renderer/patches/index.ts
@@ -8,6 +8,7 @@
 import "./enableNotificationsByDefault";
 import "./platformClass";
 import "./hideSwitchDevice";
+import "./hideVenmicInput";
 import "./screenShareFixes";
 import "./spellCheck";
 import "./windowsTitleBar";

--- a/src/renderer/patches/screenShareFixes.ts
+++ b/src/renderer/patches/screenShareFixes.ts
@@ -11,12 +11,11 @@ import { isLinux } from "renderer/utils";
 const logger = new Logger("VesktopStreamFixes");
 
 if (isLinux) {
-    const originalMedia = navigator.mediaDevices.getDisplayMedia;
-    const originalDevices = navigator.mediaDevices.enumerateDevices;
+    const original = navigator.mediaDevices.getDisplayMedia;
 
     async function getVirtmic() {
         try {
-            const devices = await originalDevices();
+            const devices = await navigator.mediaDevices.enumerateDevices();
             const audioDevice = devices.find(({ label }) => label === "vencord-screen-share");
             return audioDevice?.deviceId;
         } catch (error) {
@@ -24,13 +23,8 @@ if (isLinux) {
         }
     }
 
-    navigator.mediaDevices.enumerateDevices = async function () {
-        const result = await originalDevices.call(this);
-        return result.filter(x => x.label !== "vencord-screen-share");
-    };
-
     navigator.mediaDevices.getDisplayMedia = async function (opts) {
-        const stream = await originalMedia.call(this, opts);
+        const stream = await original.call(this, opts);
         const id = await getVirtmic();
 
         const frameRate = Number(currentSettings?.fps);


### PR DESCRIPTION
This PR fixes #504 by not patching `navigator.mediaDevices.enumerateDevices` completely but by only patching the function discord uses to retrieve input devices.