### PR TITLE
mac: add entitlements needed for camera/microphone access

### DIFF
--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -1,0 +1,21 @@
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+	<key>com.apple.security.device.camera</key>
+	<true/>
+	<key>com.apple.security.device.bluetooth</key>
+	<true/>
+	<key>com.apple.security.cs.allow-dyld-environment-variables</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+  </dict>
+</plist>


### PR DESCRIPTION
## Problem
With [Vesktop v1.5.1](https://github.com/Vencord/Vesktop/releases/tag/v1.5.1) there was a problem with Vesktop not requesting for permission and rather denying access immediately, I assume it is due to it no longer having an ad-hoc signature, though I don't exactly know the specifics but.... **adding/specifying the entitlements manually** seems to work fine.

Was pretty simple to fix, just adding the entitlements file to `build/` and electron-builder will sign with those entitlements. (not sure why it doesn't use the ones provided in `package.json`..) 

### Before
![image](https://github.com/Vencord/Vesktop/assets/97859147/9909e220-032c-45b6-8721-9b96e1094795)
![image](https://github.com/Vencord/Vesktop/assets/97859147/e46467ca-1797-4bb5-89cf-a42adf75738c)

### After 
<img width="535" alt="image" src="https://github.com/Vencord/Vesktop/assets/97859147/a00a2347-52dd-4e48-8c78-8f2ad7b79ec0">

![image](https://github.com/Vencord/Vesktop/assets/97859147/34e7efd1-5b6d-4aa2-b7a8-3edc57939aa4)

## Note
Also, assuming that it required proper entitlements when signed; camera access and access to bluetooth devices most likely didn't exactly work as well.. Though correct me if I'm wrong, I'm not gonna test it as I don't have devices neccessary.

I have also tested this on an M2 mac with a developer certificate.