### PR TITLE
fix: do not re-position on screen that was disconnected

### DIFF
--- a/src/main/mainWindow.ts
+++ b/src/main/mainWindow.ts
@@ -12,6 +12,7 @@ import {
     Menu,
     MenuItemConstructorOptions,
     nativeTheme,
+    screen,
     Tray
 } from "electron";
 import { rm } from "fs/promises";
@@ -269,7 +270,7 @@ function getWindowBoundsOptions(): BrowserWindowConstructorOptions {
         height: height ?? DEFAULT_HEIGHT
     } as BrowserWindowConstructorOptions;
 
-    if (x != null && y != null) {
+    if (x != null && y != null && State.store.display && screen.getAllDisplays().includes(State.store.display)) {
         options.x = x;
         options.y = y;
     }
@@ -317,6 +318,7 @@ function initWindowBoundsListeners(win: BrowserWindow) {
 
     const saveBounds = () => {
         State.store.windowBounds = win.getBounds();
+        State.store.display = screen.getDisplayMatching(State.store.windowBounds);
     };
 
     win.on("resize", saveBounds);

--- a/src/main/mainWindow.ts
+++ b/src/main/mainWindow.ts
@@ -270,7 +270,9 @@ function getWindowBoundsOptions(): BrowserWindowConstructorOptions {
         height: height ?? DEFAULT_HEIGHT
     } as BrowserWindowConstructorOptions;
 
-    if (x != null && y != null && State.store.display && screen.getAllDisplays().includes(State.store.display)) {
+    const storedDisplay = screen.getAllDisplays().find(display => display.id === State.store.displayid);
+
+    if (x != null && y != null && storedDisplay) {
         options.x = x;
         options.y = y;
     }
@@ -318,7 +320,7 @@ function initWindowBoundsListeners(win: BrowserWindow) {
 
     const saveBounds = () => {
         State.store.windowBounds = win.getBounds();
-        State.store.display = screen.getDisplayMatching(State.store.windowBounds);
+        State.store.displayid = screen.getDisplayMatching(State.store.windowBounds).id;
     };
 
     win.on("resize", saveBounds);

--- a/src/shared/settings.d.ts
+++ b/src/shared/settings.d.ts
@@ -4,7 +4,7 @@
  * Copyright (c) 2023 Vendicated and Vencord contributors
  */
 
-import type { Display, Rectangle } from "electron";
+import type { Rectangle } from "electron";
 
 export interface Settings {
     discordBranch?: "stable" | "canary" | "ptb";
@@ -36,7 +36,7 @@ export interface State {
     maximized?: boolean;
     minimized?: boolean;
     windowBounds?: Rectangle;
-    display?: Display;
+    displayid: int;
 
     skippedUpdate?: string;
     firstLaunch?: boolean;

--- a/src/shared/settings.d.ts
+++ b/src/shared/settings.d.ts
@@ -4,7 +4,7 @@
  * Copyright (c) 2023 Vendicated and Vencord contributors
  */
 
-import type { Rectangle } from "electron";
+import type { Display, Rectangle } from "electron";
 
 export interface Settings {
     discordBranch?: "stable" | "canary" | "ptb";
@@ -36,6 +36,7 @@ export interface State {
     maximized?: boolean;
     minimized?: boolean;
     windowBounds?: Rectangle;
+    display?: Display;
 
     skippedUpdate?: string;
     firstLaunch?: boolean;


### PR DESCRIPTION
Resolves #597. Adds a display ID in the state.json file which will then be used to determine if the previously used display is present. If the display is not present, the window will use default x & y values to position itself instead of attempting to position itself out of bounds.

~~Why Windows doesn't check for this I'm not sure~~