### PR TITLE
mac: hide native window controls with custom titlebar enabled

### DIFF
--- a/src/main/mainWindow.ts
+++ b/src/main/mainWindow.ts
@@ -430,6 +430,7 @@ function createMainWindow() {
         autoHideMenuBar: enableMenu
     }));
     win.setMenuBarVisibility(false);
+    if (process.platform === "darwin" && customTitleBar) win.setWindowButtonVisibility(false);
 
     win.on("close", e => {
         const useTray = !isDeckGameMode && Settings.store.minimizeToTray !== false && Settings.store.tray !== false;


### PR DESCRIPTION
Hides the native macOS window controls if the custom discord titlebar is enabled.

Resolves #631 

Old behavior:
![image](https://github.com/Vencord/Vesktop/assets/61215937/f0938869-405b-47de-a079-2d8c64a933f8)

New behavior:
![image](https://github.com/Vencord/Vesktop/assets/61215937/ccda8ad3-b2ad-4405-80e4-65a14a47e815)
