### PR TITLE
feat: notarization for macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,3 +51,13 @@ jobs:
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   CSC_LINK: ${{ secrets.APPLE_SIGNING_CERT }}
+
+                  # Either this:
+                  APPLE_ID: ${{ secrets.APPLE_ID }}
+                  APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }} # App specific password
+                  APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+
+                  # Or this:
+                  # APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+                  # APPLE_API_KEY_ISSUER_ID: ${{ secrets.APPLE_API_KEY_ISSUER_ID }}
+                  # APPLE_API_KEY: ${{ secrets.APPLE_API_KEY_KEY }}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vesktop",
     "version": "1.5.2",
     "private": true,
-    "description": "",
+    "description": "Vesktop is a custom Discord App aiming to give you better performance and improve linux support",
     "keywords": [],
     "homepage": "https://vencord.dev/",
     "license": "GPL-3.0",
@@ -123,13 +123,15 @@
                     ]
                 }
             ],
-            "category": "Network",
+            "category": "public.app-category.social-networking",
+            "darkModeSupport": true,
             "extendInfo": {
                 "NSMicrophoneUsageDescription": "This app needs access to the microphone",
                 "NSCameraUsageDescription": "This app needs access to the camera",
                 "com.apple.security.device.audio-input": true,
                 "com.apple.security.device.camera": true
-            }
+            },
+            "notarize": true
         },
         "dmg": {
             "background": "build/background.tiff",


### PR DESCRIPTION
draft for now ig since i dont have credentials to test this on 😋 

benefits
* no more "Cannot open Vesktop.app"
* changes to "Do you want to open this app downloaded from the internet"

why this is needed
* will stop horror support questions
* requested by almighty vee themself

[<img width="534" alt="Screenshot 2024-06-19 at 18 13 39" src="https://github.com/Vencord/Vesktop/assets/67709748/1abbb398-c539-42e7-884f-4c892d639c77">](https://discord.com/channels/1015060230222131221/1026504914131759104/1249812055641555024)

i havent tested this, but in theory it should work
