### PR TITLE
Update some broken patches

### DIFF
--- a/src/renderer/patches/enableNotificationsByDefault.ts
+++ b/src/renderer/patches/enableNotificationsByDefault.ts
@@ -13,7 +13,7 @@ addPatch({
             replacement: {
                 // FIXME: fix eslint rule
                 // eslint-disable-next-line no-useless-escape
-                match: /\.isPlatformEmbedded(?=\?\i\.DesktopNotificationTypes\.ALL)/g,
+                match: /\.isPlatformEmbedded(?=\?\i\.\i\.ALL)/g,
                 replace: "$&||true"
             }
         }

--- a/src/renderer/patches/hideSwitchDevice.tsx
+++ b/src/renderer/patches/hideSwitchDevice.tsx
@@ -12,7 +12,7 @@ addPatch({
             find: "lastOutputSystemDevice.justChanged",
             replacement: {
                 // eslint-disable-next-line no-useless-escape
-                match: /(\i)\.default\.getState\(\).neverShowModal/,
+                match: /(\i)\.\i\.getState\(\).neverShowModal/,
                 replace: "$& || $self.shouldIgnore($1)"
             }
         }


### PR DESCRIPTION
Noticed and fixed those:
```
Patch by Vesktop had no effect (Module id is 292959): /\.isPlatformEmbedded(?=\?[A-Za-z_$][\w$]*\.DesktopNotificationTypes\.ALL)/g
Patch by Vesktop had no effect (Module id is 897607): /([A-Za-z_$][\w$]*)\.default\.getState\(\).neverShowModal/
```