### PR TITLE
fix: specify framerate in constraints

### DIFF
--- a/src/renderer/components/ScreenSharePicker.tsx
+++ b/src/renderer/components/ScreenSharePicker.tsx
@@ -721,7 +721,7 @@ function ModalComponent({
 
                                 const constraints = {
                                     ...track.getConstraints(),
-                                    frameRate,
+                                    frameRate: { min: frameRate, ideal: frameRate },
                                     width: { min: 640, ideal: width, max: width },
                                     height: { min: 480, ideal: height, max: height },
                                     advanced: [{ width: width, height: height }],

--- a/src/renderer/patches/screenShareFixes.ts
+++ b/src/renderer/patches/screenShareFixes.ts
@@ -36,7 +36,7 @@ if (isLinux) {
 
         const constraints = {
             ...track.getConstraints(),
-            frameRate: { min: frameRate, ideal: frameRate},
+            frameRate: { min: frameRate, ideal: frameRate },
             width: { min: 640, ideal: width, max: width },
             height: { min: 480, ideal: height, max: height },
             advanced: [{ width: width, height: height }],

--- a/src/renderer/patches/screenShareFixes.ts
+++ b/src/renderer/patches/screenShareFixes.ts
@@ -36,7 +36,7 @@ if (isLinux) {
 
         const constraints = {
             ...track.getConstraints(),
-            frameRate,
+            frameRate: { min: frameRate, ideal: frameRate},
             width: { min: 640, ideal: width, max: width },
             height: { min: 480, ideal: height, max: height },
             advanced: [{ width: width, height: height }],


### PR DESCRIPTION
change minimum framerate to match chosen value in order to stop unnecessary frame drops on wayland (demo video attached)
especially relevant when streaming videos from a web browser
i've seen at least one other person mentioning what i believe to be this bug in the support channel on discord

this may also fix frame drops i've experienced on X11 when streaming games but i haven't tested 

discord is @puppyears if u need to ask me a question i honestly don't use github and am unfamiliar with this api, i just noticed a problem that bothered me so i tried to fix it

probably relevant information:
nvidia-dkms 555.58-1
kde plasma 6.1.1-1

https://github.com/Vencord/Vesktop/assets/95729061/3b1876b3-ffef-413c-9d08-8915802a3283