### PR TITLE
meta: Use Network category instead of AudioVideo

### DIFF
--- a/meta/dev.vencord.Vesktop.metainfo.xml
+++ b/meta/dev.vencord.Vesktop.metainfo.xml
@@ -182,7 +182,7 @@
   <url type="vcs-browser">https://github.com/Vencord/Vesktop</url>
   <categories>
     <category>InstantMessaging</category>
-    <category>AudioVideo</category>
+    <category>Network</category>
   </categories>
   <requires>
     <control>pointing</control>


### PR DESCRIPTION
Messaging applications should use the Network category, not AudioVideo.

See: https://specifications.freedesktop.org/menu-spec/latest/apa.html

---

I noticed this when I saw Vesktop on Flathub in the AudioVideo category where it looks quite out of place.