### PR TITLE
feat: Report Vesktop as a desktop client

### DIFF
--- a/src/renderer/patches/index.ts
+++ b/src/renderer/patches/index.ts
@@ -12,3 +12,4 @@ import "./hideVenmicInput";
 import "./screenShareFixes";
 import "./spellCheck";
 import "./windowsTitleBar";
+import "./reportAsClient";

--- a/src/renderer/patches/reportAsClient.ts
+++ b/src/renderer/patches/reportAsClient.ts
@@ -1,0 +1,19 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0
+ * Vesktop, a desktop app aiming to give you a snappier Discord Experience
+ * Copyright (c) 2023 Vendicated and Vencord contributors
+ */
+
+import { addPatch } from "./shared";
+
+addPatch({
+    patches: [
+        {
+            find: "_doIdentify(){",
+            replacement: {
+                match: /(let c=\{.*properties:)(l)/,
+                replace: '$1{...$2, browser: "Discord Client"}'
+            }
+        }
+    ]
+});


### PR DESCRIPTION
Adds a patch to show Vesktop as a desktop client for users of Platformindicators. Vesktop aims to be a Discord desktop replacement with all the usual desktop features. Unlike the web(which Vesktop currently reports as) version that can run on different platforms, Vesktop is only for desktops so its useful to report this to platformIndicators :3