### PR TITLE
fix(rpm): don't generate build_id links to avoid conflicts

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,6 +179,11 @@
         },
         "publish": {
             "provider": "github"
+        },
+        "rpm": {
+              "fpm": [
+                "--rpm-rpmbuild-define=_build_id_links none"
+              ]
         }
     },
     "pnpm": {
@@ -187,3 +192,4 @@
         }
     }
 }
+


### PR DESCRIPTION
On RHEL based systems a fix must be made to Electron apps to not include debugging symbols (see similar issue for vscode repository [here](https://github.com/microsoft/vscode/pull/116105/)).

This PR adds the fix to the package.json in order to build rpms without those debugging symbols and be able to install multiple electron apps without issues.