### PR TITLE
Fix downloading event ICS files

### DIFF
--- a/src/renderer/patches/downloadEventFile.tsx
+++ b/src/renderer/patches/downloadEventFile.tsx
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0
+ * Vesktop, a desktop app aiming to give you a snappier Discord Experience
+ * Copyright (c) 2024 Vendicated and Vencord contributors
+ */
+
+import { addPatch } from "./shared";
+
+addPatch({
+    patches: [
+        {
+            find: "discord-event.ics",
+            replacement: {
+                match: /("discord-event\.ics".{0,10}?)window\.open/,
+                replace: "$1$self.downloadEvent"
+            }
+        }
+    ],
+
+    downloadEvent(uri: string) {
+        const a = document.createElement("a");
+        a.href = uri;
+        a.download = "discord-event.ics";
+
+        document.body.appendChild(a);
+        a.click();
+        setImmediate(() => {
+            URL.revokeObjectURL(a.href);
+            document.body.removeChild(a);
+        });
+    }
+});

--- a/src/renderer/patches/index.ts
+++ b/src/renderer/patches/index.ts
@@ -5,6 +5,7 @@
  */
 
 // TODO: Possibly auto generate glob if we have more patches in the future
+import "./downloadEventFile";
 import "./enableNotificationsByDefault";
 import "./platformClass";
 import "./hideSwitchDevice";


### PR DESCRIPTION
Discord tries to open a blob URI in a new tab directly with window.open which doesn't work

downloadEvent function code is taken from https://github.com/Vendicated/Vencord/blob/main/src/utils/web.ts#L23-L34 without blob creation (as the URI is already a blob)