### PR TITLE
Change `VaapiVideoEncoder` to `AcceleratedVideoEncoder`

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -35,7 +35,7 @@ function init() {
     if (hardwareAcceleration === false) {
         app.disableHardwareAcceleration();
     } else {
-        enabledFeatures.push("VaapiVideoDecodeLinuxGL", "VaapiVideoEncoder", "VaapiVideoDecoder");
+        enabledFeatures.push("VaapiVideoDecodeLinuxGL", "AcceleratedVideoEncoder", "VaapiVideoDecoder");
     }
 
     if (disableSmoothScroll) {


### PR DESCRIPTION
From what I checked `VaapiVideoEncoder` doesn't seem to work when checking chrome://gpu, it keeps saying `Video Encode: Software only. Hardware acceleration disabled`. But if you use `AcceleratedVideoEncoder` it does say `Video Encode: Hardware accelerated`.

I tried verifying if this actually does something, and when using `nvtop` it does show activity on the ENC section when using `AcceleratedVideoEncoder` but it doesn't when using `VaapiVideoEncoder`.

For debugging purposes I leave my output of vainfo:
```
$ vainfo 
Trying display: wayland
libva info: VA-API version 1.22.0
libva info: Trying to open /run/opengl-driver/lib/dri/radeonsi_drv_video.so
libva info: Found init function __vaDriverInit_1_22
libva info: va_openDriver() returns 0
vainfo: VA-API version: 1.22 (libva 2.22.0)
vainfo: Driver version: Mesa Gallium driver 24.2.6 for AMD Radeon RX 7900 XTX (radeonsi, navi31, LLVM 18.1.8, DRM 3.59, 6.11.10-xanmod1)
vainfo: Supported profile and entrypoints
      VAProfileH264ConstrainedBaseline: VAEntrypointVLD
      VAProfileH264ConstrainedBaseline: VAEntrypointEncSlice
      VAProfileH264Main               : VAEntrypointVLD
      VAProfileH264Main               : VAEntrypointEncSlice
      VAProfileH264High               : VAEntrypointVLD
      VAProfileH264High               : VAEntrypointEncSlice
      VAProfileHEVCMain               : VAEntrypointVLD
      VAProfileHEVCMain               : VAEntrypointEncSlice
      VAProfileHEVCMain10             : VAEntrypointVLD
      VAProfileHEVCMain10             : VAEntrypointEncSlice
      VAProfileJPEGBaseline           : VAEntrypointVLD
      VAProfileVP9Profile0            : VAEntrypointVLD
      VAProfileVP9Profile2            : VAEntrypointVLD
      VAProfileAV1Profile0            : VAEntrypointVLD
      VAProfileAV1Profile0            : VAEntrypointEncSlice
      VAProfileNone                   : VAEntrypointVideoProc
```