### PR TITLE
Match installer requirements with Vesktop's requirements

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,5 +1,10 @@
+!include WinVer.nsh
 !macro preInit
- SetRegView 64
+${IfNot} ${AtLeastWin10}
+  MessageBox mb_iconStop "Vesktop requires at least Windows 10."
+  Abort
+${EndIf}
+SetRegView 64
   WriteRegExpandStr HKLM "${INSTALL_REGISTRY_KEY}" InstallLocation "$LocalAppData\vesktop"
   WriteRegExpandStr HKCU "${INSTALL_REGISTRY_KEY}" InstallLocation "$LocalAppData\vesktop"
  SetRegView 32

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,10 +1,10 @@
 !include WinVer.nsh
 !macro preInit
-${IfNot} ${AtLeastWin10}
+ ${IfNot} ${AtLeastWin10}
   MessageBox mb_iconStop "Vesktop requires at least Windows 10."
   Abort
-${EndIf}
-SetRegView 64
+ ${EndIf}
+ SetRegView 64
   WriteRegExpandStr HKLM "${INSTALL_REGISTRY_KEY}" InstallLocation "$LocalAppData\vesktop"
   WriteRegExpandStr HKCU "${INSTALL_REGISTRY_KEY}" InstallLocation "$LocalAppData\vesktop"
  SetRegView 32


### PR DESCRIPTION
Adds a few lines to `installer.nsh` to check for at least Windows 10. fixes #1001. nin0 said I should PR anyways