### PR TITLE
feat(rpc): implement arrpc's `link` event

### DIFF
--- a/src/main/arrpc.ts
+++ b/src/main/arrpc.ts
@@ -26,8 +26,8 @@ export async function initArRPC() {
 
             await sendRendererCommand(IpcCommands.RPC_INVITE, invite).then(callback);
         });
-        server.on("link", (data: any, deepCallback: (valid: boolean) => void) => {
-            mainWin.webContents.executeJavaScript(`Vesktop.openDeepLink(${JSON.stringify(data)})`).then(deepCallback);
+        server.on("link", async (data: any, deepCallback: (valid: boolean) => void) => {
+            await sendRendererCommand(IpcCommands.RPC_DEEP_LINK, data).then(deepCallback);
         });
     } catch (e) {
         console.error("Failed to start arRPC server", e);

--- a/src/main/arrpc.ts
+++ b/src/main/arrpc.ts
@@ -26,6 +26,9 @@ export async function initArRPC() {
 
             await sendRendererCommand(IpcCommands.RPC_INVITE, invite).then(callback);
         });
+        server.on("link", (data: any, deepCallback: (valid: boolean) => void) => {
+            mainWin.webContents.executeJavaScript(`Vesktop.openDeepLink(${JSON.stringify(data)})`).then(deepCallback);
+        });
     } catch (e) {
         console.error("Failed to start arRPC server", e);
     }

--- a/src/renderer/arrpc.ts
+++ b/src/renderer/arrpc.ts
@@ -45,7 +45,8 @@ onIpcCommand(IpcCommands.RPC_DEEP_LINK, async data => {
     try {
         DEEP_LINK.handler({ args: data });
         return true;
-    } catch {
+    } catch (err) {
+        console.error("[RPC]", "Failed to open deep link:", err, data);
         return false;
     }
 });

--- a/src/renderer/arrpc.ts
+++ b/src/renderer/arrpc.ts
@@ -5,7 +5,7 @@
  */
 
 import { onceReady } from "@vencord/types/webpack";
-import { FluxDispatcher, InviteActions } from "@vencord/types/webpack/common";
+import { FluxDispatcher, InviteActions, NavigationRouter } from "@vencord/types/webpack/common";
 import { IpcCommands } from "shared/IpcEvents";
 
 import { onIpcCommand } from "./ipcCommands";
@@ -37,4 +37,21 @@ onIpcCommand(IpcCommands.RPC_INVITE, async code => {
     });
 
     return true;
+});
+
+onIpcCommand(IpcCommands.RPC_DEEP_LINK, async data => {
+    // console.log(data);
+    if (data.type === "CHANNEL") {
+        // I am unaware of any other types but ensure just in case.
+        const { guildId, channelId, messageId } = data.params;
+        if (!guildId) return false; // ensure at least guildId exists
+
+        const path = [guildId, channelId, messageId].filter(Boolean).join("/");
+        NavigationRouter.transitionTo(`/channels/${path}`);
+
+        return true;
+    } else {
+        console.warn("Unhandled deep link type: ", data.type);
+        return false;
+    }
 });

--- a/src/renderer/arrpc.ts
+++ b/src/renderer/arrpc.ts
@@ -4,8 +4,8 @@
  * Copyright (c) 2023 Vendicated and Vencord contributors
  */
 
-import { onceReady } from "@vencord/types/webpack";
-import { FluxDispatcher, InviteActions, NavigationRouter } from "@vencord/types/webpack/common";
+import { findLazy, onceReady } from "@vencord/types/webpack";
+import { FluxDispatcher, InviteActions } from "@vencord/types/webpack/common";
 import { IpcCommands } from "shared/IpcEvents";
 
 import { onIpcCommand } from "./ipcCommands";
@@ -39,19 +39,13 @@ onIpcCommand(IpcCommands.RPC_INVITE, async code => {
     return true;
 });
 
+const { DEEP_LINK } = findLazy(m => m.DEEP_LINK?.handler);
+
 onIpcCommand(IpcCommands.RPC_DEEP_LINK, async data => {
-    // console.log(data);
-    if (data.type === "CHANNEL") {
-        // I am unaware of any other types but ensure just in case.
-        const { guildId, channelId, messageId } = data.params;
-        if (!guildId) return false; // ensure at least guildId exists
-
-        const path = [guildId, channelId, messageId].filter(Boolean).join("/");
-        NavigationRouter.transitionTo(`/channels/${path}`);
-
+    try {
+        DEEP_LINK.handler({ args: data });
         return true;
-    } else {
-        console.warn("Unhandled deep link type: ", data.type);
+    } catch {
         return false;
     }
 });

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -4,24 +4,39 @@
  * Copyright (c) 2023 Vendicated and Vencord contributors
  */
 
-import "./fixes";
-import "./appBadge";
-import "./patches";
 import "./themedSplash";
 import "./ipcCommands";
+import "./appBadge";
+import "./patches";
+import "./fixes";
 import "./arrpc";
 
 console.log("read if cute :3");
 
 export * as Components from "./components";
-import { findByPropsLazy, onceReady } from "@vencord/types/webpack";
+import { onceReady } from "@vencord/types/webpack";
 import { Alerts } from "@vencord/types/webpack/common";
 
 import SettingsUi from "./components/settings/Settings";
 import { Settings } from "./settings";
 export { Settings };
 
-const InviteActions = findByPropsLazy("resolveInvite");
+export async function openDeepLink(data: any) {
+    console.log(data);
+    if (data.type === "CHANNEL") {
+        // I am unaware of any other types but ensure just in case.
+        const { guildId, channelId, messageId } = data.params;
+        if (!guildId) return false; // ensure at least guildId exists
+
+        const path = [guildId, channelId, messageId].filter(Boolean).join("/");
+        Vencord.Webpack.Common.NavigationRouter.transitionTo(`/channels/${path}`);
+
+        return true;
+    } else {
+        console.warn("Unhandled deep link type: ", data.type);
+        return false;
+    }
+}
 
 const customSettingsSections = (
     Vencord.Plugins.plugins.Settings as any as { customSections: ((ID: Record<string, unknown>) => any)[] }

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -21,23 +21,6 @@ import SettingsUi from "./components/settings/Settings";
 import { Settings } from "./settings";
 export { Settings };
 
-export async function openDeepLink(data: any) {
-    console.log(data);
-    if (data.type === "CHANNEL") {
-        // I am unaware of any other types but ensure just in case.
-        const { guildId, channelId, messageId } = data.params;
-        if (!guildId) return false; // ensure at least guildId exists
-
-        const path = [guildId, channelId, messageId].filter(Boolean).join("/");
-        Vencord.Webpack.Common.NavigationRouter.transitionTo(`/channels/${path}`);
-
-        return true;
-    } else {
-        console.warn("Unhandled deep link type: ", data.type);
-        return false;
-    }
-}
-
 const customSettingsSections = (
     Vencord.Plugins.plugins.Settings as any as { customSections: ((ID: Record<string, unknown>) => any)[] }
 ).customSections;

--- a/src/renderer/patches/index.ts
+++ b/src/renderer/patches/index.ts
@@ -12,3 +12,4 @@ import "./hideVenmicInput";
 import "./screenShareFixes";
 import "./spellCheck";
 import "./windowsTitleBar";
+import "./nativeFocus";

--- a/src/renderer/patches/nativeFocus.tsx
+++ b/src/renderer/patches/nativeFocus.tsx
@@ -14,8 +14,8 @@ addPatch({
                 {
                     // TODO: Fix eslint rule
                     // eslint-disable-next-line no-useless-escape
-                    match: /switch\(\i.\i.focus\(\)/,
-                    replace: "switch(VesktopNative.win.focus()"
+                    match: /(?<=\.DEEP_LINK.{0,200}?)\i\.\i\.focus\(\)/,
+                    replace: "VesktopNative.win.focus()"
                 }
             ]
         }

--- a/src/renderer/patches/nativeFocus.tsx
+++ b/src/renderer/patches/nativeFocus.tsx
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0
+ * Vesktop, a desktop app aiming to give you a snappier Discord Experience
+ * Copyright (c) 2023 Vendicated and Vencord contributors
+ */
+
+import { addPatch } from "./shared";
+
+addPatch({
+    patches: [
+        {
+            find: ".DEEP_LINK]:{",
+            replacement: [
+                {
+                    // TODO: Fix eslint rule
+                    // eslint-disable-next-line no-useless-escape
+                    match: /switch\(\i.\i.focus\(\)/,
+                    replace: "switch(VesktopNative.win.focus()"
+                }
+            ]
+        }
+    ]
+});

--- a/src/shared/IpcEvents.ts
+++ b/src/shared/IpcEvents.ts
@@ -61,6 +61,7 @@ export const enum IpcEvents {
 export const enum IpcCommands {
     RPC_ACTIVITY = "rpc:activity",
     RPC_INVITE = "rpc:invite",
+    RPC_DEEP_LINK = "rpc:deep",
     NAVIGATE_SETTINGS = "navigate:settings",
     GET_LANGUAGES = "navigator.languages"
 }

--- a/src/shared/IpcEvents.ts
+++ b/src/shared/IpcEvents.ts
@@ -61,7 +61,7 @@ export const enum IpcEvents {
 export const enum IpcCommands {
     RPC_ACTIVITY = "rpc:activity",
     RPC_INVITE = "rpc:invite",
-    RPC_DEEP_LINK = "rpc:deep",
+    RPC_DEEP_LINK = "rpc:link",
     NAVIGATE_SETTINGS = "navigate:settings",
     GET_LANGUAGES = "navigator.languages"
 }


### PR DESCRIPTION
This implements deep links from web so message links and the like work over just invites working.

Depends on OpenAsar/arrpc/pull/128


I noticed we didn't implement this after double checking what I said in a #813 comment


note: you need to be signed out of web for discord to prompt you for this