### PR TITLE
Add 4k resolution to screenshare

### DIFF
--- a/src/renderer/components/ScreenSharePicker.tsx
+++ b/src/renderer/components/ScreenSharePicker.tsx
@@ -25,7 +25,7 @@ import { addPatch } from "renderer/patches/shared";
 import { useSettings } from "renderer/settings";
 import { isLinux, isWindows } from "renderer/utils";
 
-const StreamResolutions = ["480", "720", "1080", "1440"] as const;
+const StreamResolutions = ["480", "720", "1080", "1440", "2160"] as const;
 const StreamFps = ["15", "30", "60"] as const;
 
 const MediaEngineStore = findStoreLazy("MediaEngineStore");


### PR DESCRIPTION
Vanilla client supports sharing screen in 4k.
Patch gui preview:
![screenshare dialog preview with 4k](https://github.com/user-attachments/assets/cc913b81-9e4f-4319-a518-0993192298f8)

Due to other issues with screenshare main purpose for it is screensharing text (e.g. code), because it is still low quality comparing to original windows discord client 😔