### PR TITLE
Adding support for 8K and 120FPS to screenshare 

### DIFF
--- a/src/renderer/components/ScreenSharePicker.tsx
+++ b/src/renderer/components/ScreenSharePicker.tsx
@@ -25,8 +25,8 @@ import { addPatch } from "renderer/patches/shared";
 import { useSettings } from "renderer/settings";
 import { isLinux, isWindows } from "renderer/utils";
 
-const StreamResolutions = ["480", "720", "1080", "1440"] as const;
-const StreamFps = ["15", "30", "60"] as const;
+const StreamResolutions = ["480", "720", "1080", "1440" , "2160", "4320"] as const;
+const StreamFps = ["15", "30", "60", "120"] as const;
 
 const MediaEngineStore = findStoreLazy("MediaEngineStore");
 


### PR DESCRIPTION
Add further support for 8K streaming as well as an option to stream 120 FPS as well.

A modified version of the original pull request #1024 . 