### PR TITLE
README.md: add slackware link to unofficial repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Below you can find unofficial packages created by the community. They are not of
 
 - Arch Linux: [Vesktop on the Arch user repository](https://aur.archlinux.org/packages?K=vesktop)
 - NixOS: https://wiki.nixos.org/wiki/Discord#Vesktop
+- Slackware: [Vesktop on the SlackBuilds](https://slackbuilds.org/result/?search=vesktop)
 - Windows - Scoop: https://scoop.sh/#/apps?q=Vesktop
 
 ## Building from Source


### PR DESCRIPTION
I thought it's not bad people to add extra info, I recently came around this and it made wayland screensharing less pain in the neck,

Thank you guys for developing this!