### PR TITLE
feat: Add a toggle in the settings for video hardware acceleration

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -31,14 +31,16 @@ process.env.VENCORD_USER_DATA_DIR = DATA_DIR;
 function init() {
     app.setAsDefaultProtocolClient("discord");
 
-    const { disableSmoothScroll, hardwareAcceleration } = Settings.store;
+    const { disableSmoothScroll, hardwareAcceleration, videoHardwareAcceleration } = Settings.store;
 
     const enabledFeatures = app.commandLine.getSwitchValue("enable-features").split(",");
     const disabledFeatures = app.commandLine.getSwitchValue("disable-features").split(",");
 
     if (hardwareAcceleration === false) {
         app.disableHardwareAcceleration();
-    } else {
+    }
+    
+    if (hardwareAcceleration && videoHardwareAcceleration) {
         enabledFeatures.push(
             "AcceleratedVideoDecodeLinuxGL",
             "AcceleratedVideoEncoder",

--- a/src/renderer/components/settings/Settings.tsx
+++ b/src/renderer/components/settings/Settings.tsx
@@ -38,6 +38,13 @@ const SettingsOptions: Record<string, Array<BooleanSetting | SettingsComponent>>
             title: "Hardware Acceleration",
             description: "Enable hardware acceleration",
             defaultValue: true
+        },
+        {
+            key: "videoHardwareAcceleration",
+            title: "Video Hardware Acceleration",
+            description: "Improves screensharing performance. May cause color glitches. Requires a full restart.",
+            defaultValue: true,
+            disabled: () => Settings.store.hardwareAcceleration === false
         }
     ],
     "User Interface": [

--- a/src/shared/settings.d.ts
+++ b/src/shared/settings.d.ts
@@ -16,6 +16,7 @@ export interface Settings {
     enableMenu?: boolean;
     disableSmoothScroll?: boolean;
     hardwareAcceleration?: boolean;
+    videoHardwareAcceleration?: boolean;
     arRPC?: boolean;
     appBadge?: boolean;
     disableMinSize?: boolean;


### PR DESCRIPTION
Adds a toggle for video hardware acceleration in the Vesktop Settings while keeping overall hardware acceleration turned on, since video hardware acceleration may cause screen-share issues in some systems.

Would add a workaround to issues like #1107, #1004, #851 and #797 