### PR TITLE
fix: don't close app on Ctrl+W

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -6,7 +6,7 @@
 
 import "./ipc";
 
-import { app, BrowserWindow, nativeTheme } from "electron";
+import { app, BrowserWindow, globalShortcut, nativeTheme } from "electron";
 import { autoUpdater } from "electron-updater";
 
 import { DATA_DIR } from "./constants";
@@ -97,6 +97,9 @@ function init() {
 
         app.on("activate", () => {
             if (BrowserWindow.getAllWindows().length === 0) createWindows();
+        });
+        globalShortcut.register("CommandOrControl+W", () => {
+            // Ignore
         });
     });
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -6,7 +6,7 @@
 
 import "./ipc";
 
-import { app, BrowserWindow, globalShortcut, nativeTheme } from "electron";
+import { app, BrowserWindow, nativeTheme } from "electron";
 import { autoUpdater } from "electron-updater";
 
 import { DATA_DIR } from "./constants";
@@ -97,9 +97,6 @@ function init() {
 
         app.on("activate", () => {
             if (BrowserWindow.getAllWindows().length === 0) createWindows();
-        });
-        globalShortcut.register("CommandOrControl+W", () => {
-            // Ignore
         });
     });
 }

--- a/src/main/mainWindow.ts
+++ b/src/main/mainWindow.ts
@@ -253,8 +253,7 @@ function initMenuBar(win: BrowserWindow) {
         },
         { role: "fileMenu" },
         { role: "editMenu" },
-        { role: "viewMenu" },
-        { role: "windowMenu" }
+        { role: "viewMenu" }
     ]);
 
     Menu.setApplicationMenu(menu);


### PR DESCRIPTION
Matches stock client behavior. If people want this back, they should add a keybind to their WM instead, which makes it configurable.

Fixes #934