### PR TITLE
feat: stock discord zooming

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -93,6 +93,10 @@ handle(IpcEvents.MAXIMIZE, e => {
     }
 });
 
+handle(IpcEvents.SET_ZOOM_FACTOR, (e, factor: number) => {
+    e.sender.setZoomFactor(factor);
+});
+
 handleSync(IpcEvents.SPELLCHECK_GET_AVAILABLE_LANGUAGES, e => {
     e.returnValue = session.defaultSession.availableSpellCheckerLanguages;
 });

--- a/src/main/mainWindow.ts
+++ b/src/main/mainWindow.ts
@@ -236,12 +236,23 @@ function initMenuBar(win: BrowserWindow) {
                 app.quit();
             }
         },
-        // See https://github.com/electron/electron/issues/14742 and https://github.com/electron/electron/issues/5256
         {
-            label: "Zoom in (hidden, hack for Qwertz and others)",
+            label: "Zoom out",
+            accelerator: "CmdOrCtrl+-",
+            visible: false,
+            click: () => sendRendererCommand(IpcCommands.ZOOM_OUT)
+        },
+        {
+            label: "Zoom in",
             accelerator: "CmdOrCtrl+=",
-            role: "zoomIn",
-            visible: false
+            visible: false,
+            click: () => sendRendererCommand(IpcCommands.ZOOM_IN)
+        },
+        {
+            label: "Reset zoom",
+            accelerator: "CmdOrCtrl+0",
+            visible: false,
+            click: () => sendRendererCommand(IpcCommands.ZOOM_RESET)
         }
     ] satisfies MenuItemList;
 
@@ -253,7 +264,6 @@ function initMenuBar(win: BrowserWindow) {
         },
         { role: "fileMenu" },
         { role: "editMenu" },
-        { role: "viewMenu" },
         { role: "windowMenu" }
     ]);
 

--- a/src/preload/VesktopNative.ts
+++ b/src/preload/VesktopNative.ts
@@ -56,7 +56,8 @@ export const VesktopNative = {
         focus: () => invoke<void>(IpcEvents.FOCUS),
         close: (key?: string) => invoke<void>(IpcEvents.CLOSE, key),
         minimize: () => invoke<void>(IpcEvents.MINIMIZE),
-        maximize: () => invoke<void>(IpcEvents.MAXIMIZE)
+        maximize: () => invoke<void>(IpcEvents.MAXIMIZE),
+        setZoomFactor: (factor: number) => invoke<void>(IpcEvents.SET_ZOOM_FACTOR, factor)
     },
     capturer: {
         getLargeThumbnail: (id: string) => invoke<string>(IpcEvents.CAPTURER_GET_LARGE_THUMBNAIL, id)

--- a/src/renderer/patches/index.ts
+++ b/src/renderer/patches/index.ts
@@ -15,3 +15,4 @@ import "./windowsTitleBar";
 import "./streamerMode";
 import "./nativeFocus";
 import "./hideDownloadAppsButton";
+import "./vesktopZoom";

--- a/src/renderer/patches/vesktopZoom.ts
+++ b/src/renderer/patches/vesktopZoom.ts
@@ -1,0 +1,67 @@
+/*
+ * Vesktop, a desktop app aiming to give you a snappier Discord Experience
+ * Copyright (c) 2023 Vendicated and Vencord contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { findByPropsLazy, findStoreLazy } from "@vencord/types/webpack";
+import { FluxDispatcher } from "@vencord/types/webpack/common";
+
+import { IpcCommands } from "../../shared/IpcEvents";
+import { onIpcCommand } from "../ipcCommands";
+import { addPatch } from "./shared";
+
+// Allows app zoom to function in Vesktop
+
+const AccessibilityStore = findStoreLazy("AccessibilityStore");
+const ScalingConstants = findByPropsLazy("ZOOM_SCALES");
+
+addPatch({
+    patches: [
+        {
+            // Re-enable the zoom slider in appearance settings
+            find: ".Component{renderZoomSlider(){",
+            replacement: [
+                {
+                    // eslint-disable-next-line no-useless-escape
+                    match: /(renderZoomSlider\(\)\{.+?return) \i\.isPlatformEmbedded/,
+                    replace: "$1 true"
+                }
+            ]
+        },
+        {
+            // Redirect DiscordNative calls for setZoomFactor to VesktopNative
+            find: '"discord_erlpack","discord_game_utils","discord_rpc","discord_spellcheck","discord_utils","discord_voice"',
+            replacement: {
+                // eslint-disable-next-line no-useless-escape
+                match: /setZoomFactor:(\i)=>/,
+                replace: "$& VesktopNative.win.setZoomFactor($1 / 100) &&"
+            }
+        }
+    ]
+});
+
+onIpcCommand(IpcCommands.ZOOM_IN, () => {
+    FluxDispatcher.dispatch({
+        type: "ACCESSIBILITY_SET_ZOOM",
+        zoom: getNextZoomScale(1)
+    });
+});
+
+onIpcCommand(IpcCommands.ZOOM_OUT, () => {
+    FluxDispatcher.dispatch({
+        type: "ACCESSIBILITY_SET_ZOOM",
+        zoom: getNextZoomScale(-1)
+    });
+});
+
+onIpcCommand(IpcCommands.ZOOM_RESET, () => {
+    FluxDispatcher.dispatch({ type: "ACCESSIBILITY_RESET_TO_DEFAULT" });
+});
+
+function getNextZoomScale(next: number): number {
+    const scales = ScalingConstants.ZOOM_SCALES as number[];
+    const zoom = AccessibilityStore.zoom as number;
+
+    return scales[Math.max(0, Math.min(scales.indexOf(zoom) + next, scales.length - 1))];
+}

--- a/src/shared/IpcEvents.ts
+++ b/src/shared/IpcEvents.ts
@@ -19,6 +19,8 @@ export const enum IpcEvents {
     MINIMIZE = "VCD_MINIMIZE",
     MAXIMIZE = "VCD_MAXIMIZE",
 
+    SET_ZOOM_FACTOR = "VCD_SET_ZOOM_FACTOR",
+
     SHOW_ITEM_IN_FOLDER = "VCD_SHOW_ITEM_IN_FOLDER",
     GET_SETTINGS = "VCD_GET_SETTINGS",
     SET_SETTINGS = "VCD_SET_SETTINGS",
@@ -63,5 +65,8 @@ export const enum IpcCommands {
     RPC_INVITE = "rpc:invite",
     RPC_DEEP_LINK = "rpc:link",
     NAVIGATE_SETTINGS = "navigate:settings",
-    GET_LANGUAGES = "navigator.languages"
+    GET_LANGUAGES = "navigator.languages",
+    ZOOM_IN = "zoom:in",
+    ZOOM_OUT = "zoom:out",
+    ZOOM_RESET = "zoom:reset"
 }


### PR DESCRIPTION
Connects electron keybinds to Discord's internal zoom handling, and re-enables the zoom slider in appearance settings

FIXME:
- figure out what to do with incompatible default electron `viewMenu`

Fixes #1018