### PR TITLE
feat: prevent mainWin from being used after destroyed

### DIFF
--- a/src/main/appBadge.ts
+++ b/src/main/appBadge.ts
@@ -42,7 +42,7 @@ export function setBadgeCount(count: number) {
 
             // circular import shenanigans
             const { mainWin } = require("./mainWindow") as typeof import("./mainWindow");
-            mainWin.setOverlayIcon(index === null ? null : loadBadge(index), description);
+            mainWin?.setOverlayIcon(index === null ? null : loadBadge(index), description);
             break;
     }
 }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -69,8 +69,8 @@ handle(IpcEvents.SHOW_ITEM_IN_FOLDER, (_, path) => {
 });
 
 handle(IpcEvents.FOCUS, () => {
-    mainWin.show();
-    mainWin.setSkipTaskbar(false);
+    mainWin?.show();
+    mainWin?.setSkipTaskbar(false);
 });
 
 handle(IpcEvents.CLOSE, (e, key?: string) => {
@@ -82,14 +82,14 @@ handle(IpcEvents.CLOSE, (e, key?: string) => {
 });
 
 handle(IpcEvents.MINIMIZE, e => {
-    mainWin.minimize();
+    mainWin?.minimize();
 });
 
 handle(IpcEvents.MAXIMIZE, e => {
-    if (mainWin.isMaximized()) {
-        mainWin.unmaximize();
+    if (mainWin?.isMaximized()) {
+        mainWin?.unmaximize();
     } else {
-        mainWin.maximize();
+        mainWin?.maximize();
     }
 });
 

--- a/src/main/ipcCommands.ts
+++ b/src/main/ipcCommands.ts
@@ -37,7 +37,7 @@ export function sendRendererCommand<T = any>(message: string, data?: any) {
         resolvers.set(nonce, { resolve, reject });
     });
 
-    mainWin.webContents.send(IpcEvents.IPC_COMMAND, { nonce, message, data });
+    mainWin?.webContents.send(IpcEvents.IPC_COMMAND, { nonce, message, data });
 
     return promise;
 }

--- a/src/main/mainWindow.ts
+++ b/src/main/mainWindow.ts
@@ -53,7 +53,7 @@ app.on("before-quit", () => {
     isQuitting = true;
 });
 
-export let mainWin: BrowserWindow;
+export let mainWin: BrowserWindow | null = null;
 
 function makeSettingsListenerHelpers<O extends object>(o: SettingsStore<O>) {
     const listeners = new Map<(data: any) => void, PropertyKey>();
@@ -454,7 +454,10 @@ function createMainWindow() {
 
     win.on("close", e => {
         const useTray = !isDeckGameMode && Settings.store.minimizeToTray !== false && Settings.store.tray !== false;
-        if (isQuitting || (process.platform !== "darwin" && !useTray)) return;
+        if (isQuitting || (process.platform !== "darwin" && !useTray)) {
+            mainWin = null;
+            return;
+        }
 
         e.preventDefault();
 
@@ -485,7 +488,7 @@ const runVencordMain = once(() => require(join(VENCORD_FILES_DIR, "vencordDeskto
 export function loadUrl(uri: string | undefined) {
     const branch = Settings.store.discordBranch;
     const subdomain = branch === "canary" || branch === "ptb" ? `${branch}.` : "";
-    mainWin.loadURL(`https://${subdomain}discord.com/${uri ? new URL(uri).pathname.slice(1) || "app" : "app"}`);
+    mainWin?.loadURL(`https://${subdomain}discord.com/${uri ? new URL(uri).pathname.slice(1) || "app" : "app"}`);
 }
 
 export async function createWindows() {
@@ -516,10 +519,10 @@ export async function createWindows() {
             // always use entire display
             mainWin!.setFullScreen(true);
 
-            askToApplySteamLayout(mainWin);
+            askToApplySteamLayout(mainWin!);
         }
 
-        mainWin.once("show", () => {
+        mainWin!.once("show", () => {
             if (State.store.maximized && !mainWin!.isMaximized() && !isDeckGameMode) {
                 mainWin!.maximize();
             }


### PR DESCRIPTION
Fixes #808

> The code triggering this seems to have changed a bit since this issue was created, but it seems to partially be caused by arrpc outliving the main browser window?
https://github.com/Vencord/Vesktop/commit/c9be6181644a329ce6556c49186e56e2b7d5e8e2#diff-53486cd162d85eb4faf85f2b936105851979cd772b7be0b7bc48ae85efbbb9e9L22-R22
(arrpc server tries to use `mainWin` to send an IPC event after it's already been destroyed?)