### PR TITLE
fix: allow DevTools keybind to propagate

### DIFF
--- a/src/renderer/patches/allowDevToolsKeybind.ts
+++ b/src/renderer/patches/allowDevToolsKeybind.ts
@@ -1,0 +1,20 @@
+/*
+ * Vesktop, a desktop app aiming to give you a snappier Discord Experience
+ * Copyright (c) 2025 Vendicated and Vesktop contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { addPatch } from "./shared";
+
+addPatch({
+    patches: [
+        {
+            find: '"mod+alt+i"',
+            replacement: {
+                // eslint-disable-next-line no-useless-escape
+                match: /\(0,\i.isWeb\)\(\)&&"discord\.com"===location\.host/,
+                replace: "false"
+            }
+        }
+    ]
+});

--- a/src/renderer/patches/index.ts
+++ b/src/renderer/patches/index.ts
@@ -7,6 +7,7 @@
 // TODO: Possibly auto generate glob if we have more patches in the future
 import "./enableNotificationsByDefault";
 import "./platformClass";
+import "./allowDevToolsKeybind";
 import "./hideSwitchDevice";
 import "./hideVenmicInput";
 import "./screenShareFixes";


### PR DESCRIPTION
The added patch prevents the Discord web app from stopping propagation of the DevTools keybind keyboard event to Vesktop.

Closes #963.
