### PR TITLE
fix: promote spellcheck toggle to top-level context menu

### DIFF
--- a/src/renderer/patches/spellCheck.tsx
+++ b/src/renderer/patches/spellCheck.tsx
@@ -61,56 +61,66 @@ addContextMenuPatch("textarea-context", children => {
     children.splice(
         pasteSectionIndex === -1 ? children.length : pasteSectionIndex,
         0,
-        <Menu.MenuGroup>
+        <Menu.MenuGroup key="vcd-spellcheck-group">
             {hasCorrections && (
                 <>
                     {corrections.map(c => (
                         <Menu.MenuItem
-                            id={"vcd-spellcheck-suggestion-" + c}
+                            key={`vcd-spellcheck-suggestion-${c}`}
+                            id={`vcd-spellcheck-suggestion-${c}`}
                             label={c}
                             action={() => VesktopNative.spellcheck.replaceMisspelling(c)}
                         />
                     ))}
-                    <Menu.MenuSeparator />
+                    <Menu.MenuSeparator key="vcd-spellcheck-separator-1" />
                     <Menu.MenuItem
+                        key="vcd-spellcheck-learn"
                         id="vcd-spellcheck-learn"
-                        label={`Add ${word} to dictionary`}
+                        label={`Add "${word}" to dictionary`}
                         action={() => VesktopNative.spellcheck.addToDictionary(word)}
                     />
+                    <Menu.MenuSeparator key="vcd-spellcheck-separator-2" />
                 </>
             )}
 
-            <Menu.MenuItem id="vcd-spellcheck-settings" label="Spellcheck Settings">
-                <Menu.MenuCheckboxItem
-                    id="vcd-spellcheck-enabled"
-                    label="Enable Spellcheck"
-                    checked={spellCheckEnabled}
-                    action={() => {
-                        FluxDispatcher.dispatch({ type: "SPELLCHECK_TOGGLE" });
-                    }}
-                />
+            {/* Primary toggle - directly accessible for best UX */}
+            <Menu.MenuCheckboxItem
+                key="vcd-spellcheck-enabled"
+                id="vcd-spellcheck-enabled"
+                label="Enable Spellcheck"
+                checked={spellCheckEnabled}
+                action={() => {
+                    FluxDispatcher.dispatch({ type: "SPELLCHECK_TOGGLE" });
+                }}
+            />
 
-                <Menu.MenuItem id="vcd-spellcheck-languages" label="Languages" disabled={!spellCheckEnabled}>
-                    {availableLanguages.map(lang => {
-                        const isEnabled = spellCheckLanguages.includes(lang);
-                        return (
-                            <Menu.MenuCheckboxItem
-                                id={"vcd-spellcheck-lang-" + lang}
-                                label={lang}
-                                checked={isEnabled}
-                                disabled={!isEnabled && spellCheckLanguages.length >= 5}
-                                action={() => {
-                                    const newSpellCheckLanguages = spellCheckLanguages.filter(l => l !== lang);
-                                    if (newSpellCheckLanguages.length === spellCheckLanguages.length) {
-                                        newSpellCheckLanguages.push(lang);
-                                    }
+            {/* Language settings in submenu - less frequently used */}
+            <Menu.MenuItem
+                key="vcd-spellcheck-languages"
+                id="vcd-spellcheck-languages"
+                label="Spellcheck Languages"
+                disabled={!spellCheckEnabled}
+            >
+                {availableLanguages.map(lang => {
+                    const isEnabled = spellCheckLanguages.includes(lang);
+                    return (
+                        <Menu.MenuCheckboxItem
+                            key={`vcd-spellcheck-lang-${lang}`}
+                            id={`vcd-spellcheck-lang-${lang}`}
+                            label={lang}
+                            checked={isEnabled}
+                            disabled={!isEnabled && spellCheckLanguages.length >= 5}
+                            action={() => {
+                                const newSpellCheckLanguages = spellCheckLanguages.filter(l => l !== lang);
+                                if (newSpellCheckLanguages.length === spellCheckLanguages.length) {
+                                    newSpellCheckLanguages.push(lang);
+                                }
 
-                                    settings.spellCheckLanguages = newSpellCheckLanguages;
-                                }}
-                            />
-                        );
-                    })}
-                </Menu.MenuItem>
+                                settings.spellCheckLanguages = newSpellCheckLanguages;
+                            }}
+                        />
+                    );
+                })}
             </Menu.MenuItem>
         </Menu.MenuGroup>
     );


### PR DESCRIPTION
## Fix missing "Enable Spellcheck" option in context menu

### Description
- Resolves issue where "Enable Spellcheck" toggle disappeared from spellcheck context menu
- Flattens spellcheck menu structure by moving the main toggle out of nested submenu
- Improves UX by making spellcheck enable/disable more accessible

### Changes
- Restructured spellcheck context menu items to show "Enable Spellcheck" at top level
- Maintained language selection in submenu while promoting main toggle
- Ensures spellcheck functionality remains easily discoverable

**Fixes:** #434  
**Type:** Bug fix  
**Component:** Context menu / Spellcheck
