### PR TITLE
fix: re-add tray icon to macOS

### DIFF
--- a/src/main/mainWindow.ts
+++ b/src/main/mainWindow.ts
@@ -130,8 +130,6 @@ function initTray(win: BrowserWindow) {
     if (process.platform === "darwin") {
         const icon = nativeImage.createFromPath(ICON_PATH)
             .resize({ width: 16 });
-        icon.setTemplateImage(true);
-
         tray = new Tray(icon);
     } else {
         tray = new Tray(ICON_PATH);

--- a/src/main/mainWindow.ts
+++ b/src/main/mainWindow.ts
@@ -44,6 +44,7 @@ import { createSplashWindow, updateSplashMessage } from "./splash";
 import { makeLinksOpenExternally } from "./utils/makeLinksOpenExternally";
 import { applyDeckKeyboardFix, askToApplySteamLayout, isDeckGameMode } from "./utils/steamOS";
 import { downloadVencordFiles, ensureVencordFiles } from "./utils/vencordLoader";
+import { nativeImage } from "electron/common";
 
 let isQuitting = false;
 let tray: Tray;
@@ -126,7 +127,16 @@ function initTray(win: BrowserWindow) {
         }
     ]);
 
-    tray = new Tray(ICON_PATH);
+    if (process.platform === "darwin") {
+        const icon = nativeImage.createFromPath(ICON_PATH)
+            .resize({ width: 16 });
+        icon.setTemplateImage(true);
+
+        tray = new Tray(icon);
+    } else {
+        tray = new Tray(ICON_PATH);
+    }
+
     tray.setToolTip("Vesktop");
     tray.setContextMenu(trayMenu);
     tray.on("click", onTrayClick);
@@ -477,7 +487,7 @@ function createMainWindow() {
     });
 
     initWindowBoundsListeners(win);
-    if (!isDeckGameMode && (Settings.store.tray ?? true) && process.platform !== "darwin") initTray(win);
+    if (!isDeckGameMode && (Settings.store.tray ?? true)) initTray(win);
     initMenuBar(win);
     makeLinksOpenExternally(win);
     initSettingsListeners(win);


### PR DESCRIPTION
I just noticed that when I open Vesktop on macOS, it has no tray icon. This was removed in #68 due to its super big size on the menu bar.

This PR fixed it by resizing the icon first instead of passing the icon directly to the tray constructor

<img width="394" height="378" alt="image" src="https://github.com/user-attachments/assets/95cc9842-4f07-4c9d-a841-a53543933e8d" />
