### PR TITLE
Fix excessive GPU usage on macOS 26 (Tahoe)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "@types/react": "19.2.1",
         "@vencord/types": "^1.13.2",
         "dotenv": "^17.2.3",
-        "electron": "^38.0.0",
+        "electron": "^38.3.0",
         "electron-builder": "^26.0.12",
         "esbuild": "^0.25.10",
         "eslint": "^9.37.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^17.2.3
         version: 17.2.3
       electron:
-        specifier: ^38.0.0
-        version: 38.0.0
+        specifier: ^38.3.0
+        version: 38.3.0
       electron-builder:
         specifier: ^26.0.12
         version: 26.0.12(electron-builder-squirrel-windows@25.1.8)
@@ -1119,8 +1119,8 @@ packages:
   electron-updater@6.6.2:
     resolution: {integrity: sha512-Cr4GDOkbAUqRHP5/oeOmH/L2Bn6+FQPxVLZtPbcmKZC63a1F3uu5EefYOssgZXG3u/zBlubbJ5PJdITdMVggbw==}
 
-  electron@38.0.0:
-    resolution: {integrity: sha512-egljptiPJqbL/oamFCEY+g3RNeONWTVxZSGeyLqzK8xq106JhzuxnhJZ3sxt4DzJFaofbGyGJA37Oe9d+gVzYw==}
+  electron@38.3.0:
+    resolution: {integrity: sha512-Wij4AzX4SAV0X/ktq+NrWrp5piTCSS8F6YWh1KAcG+QRtNzyns9XLKERP68nFHIwfprhxF2YCN2uj7nx9DaeJw==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
 
@@ -4248,7 +4248,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@38.0.0:
+  electron@38.3.0:
     dependencies:
       '@electron/get': 2.0.3
       '@types/node': 22.18.8


### PR DESCRIPTION
Since macOS 26 (Tahoe), [all electron apps cause excessive GPU usage](https://github.com/electron/electron/issues/48311) since Electron has been abusing a private API which has something to do how window shadows are rendered.

This has been fixed by the Electron team in Electron [v36.9.2](https://github.com/electron/electron/releases/tag/v36.9.2), [v37.6.0](https://github.com/electron/electron/releases/tag/v37.6.0), and [v38.2.0](https://github.com/electron/electron/releases/tag/v38.2.0).

So this PR bumps the Electron version to [v38.3.0](https://github.com/electron/electron/releases/tag/v38.3.0).

Before:
![ScreenShot 2025-10-22 at 12 44 AM](https://github.com/user-attachments/assets/b794fd8b-ee54-4206-9352-036c4d706402)
After:
![ScreenShot 2025-10-22 at 12 52 AM](https://github.com/user-attachments/assets/acbda21e-fbb6-4e4a-835b-a7917364b3a6)
