### PR TITLE
feat: add voice settings management in arRPC

### DIFF
--- a/patches/arrpc@3.5.0.patch
+++ b/patches/arrpc@3.5.0.patch
@@ -1,5 +1,5 @@
 diff --git a/src/process/index.js b/src/process/index.js
-index 389b0845256a34b4536d6da99edb00d17f13a6b4..f17a0ac687e9110ebfd33cb91fd2f6250d318643 100644
+index f445024f14ecfe5ee0eb70fe42535591c76838dc..4f089d035202a611ad5f18a74925e8d273a095b4 100644
 --- a/src/process/index.js
 +++ b/src/process/index.js
 @@ -5,8 +5,20 @@ import fs from 'node:fs';
@@ -25,3 +25,247 @@ index 389b0845256a34b4536d6da99edb00d17f13a6b4..f17a0ac687e9110ebfd33cb91fd2f625
  
  import * as Natives from './native/index.js';
  const Native = Natives[process.platform];
+diff --git a/src/server.js b/src/server.js
+index e016f9694e7fad2686daab5716d635f48b0af810..cc0e69dcd3a7c0941ba9f58d34a079b2cea59af3 100644
+--- a/src/server.js
++++ b/src/server.js
+@@ -8,6 +8,17 @@ import WSServer from './transports/websocket.js';
+ import ProcessServer from './process/index.js';
+ 
+ let socketId = 0;
++const mockUser = {
++  id: '1045800378228281345',
++  username: 'arrpc',
++  discriminator: '0',
++  global_name: 'arRPC',
++  avatar: 'cfefa4d9839fb4bdf030f91c2a13e95c',
++  avatar_decoration_data: null,
++  bot: false,
++  flags: 0,
++  premium_type: 0,
++};
+ export default class RPCServer extends EventEmitter {
+   constructor() { super(); return (async () => {
+     this.onConnection = this.onConnection.bind(this);
+@@ -25,6 +36,9 @@ export default class RPCServer extends EventEmitter {
+ 
+     if (!process.argv.includes('--no-process-scanning') && !process.env.ARRPC_NO_PROCESS_SCANNING) this.process = await new ProcessServer(handlers);
+ 
++    this.voiceSettingsSubscribers = new Set();
++    this.voiceStateSubscribers = new Set();
++
+     return this;
+   })(); }
+ 
+@@ -38,17 +52,7 @@ export default class RPCServer extends EventEmitter {
+           api_endpoint: '//discord.com/api',
+           environment: 'production'
+         },
+-        user: { // mock user data using arRPC app/bot
+-          id: '1045800378228281345',
+-          username: 'arrpc',
+-          discriminator: '0',
+-          global_name: 'arRPC',
+-          avatar: 'cfefa4d9839fb4bdf030f91c2a13e95c',
+-          avatar_decoration_data: null,
+-          bot: false,
+-          flags: 0,
+-          premium_type: 0,
+-        }
++        user: mockUser // mock user data using arRPC app/bot
+       },
+       evt: 'READY',
+       nonce: null
+@@ -66,10 +70,13 @@ export default class RPCServer extends EventEmitter {
+       socketId: socket.socketId.toString()
+     });
+ 
++    this.voiceSettingsSubscribers?.delete(socket);
++    this.voiceStateSubscribers?.delete(socket);
++
+     this.emit('close', socket);
+   }
+ 
+-  async onMessage(socket, { cmd, args, nonce }) {
++  async onMessage(socket, { cmd, args, nonce, evt }) {
+     this.emit('message', { socket, cmd, args, nonce });
+ 
+     switch (cmd) {
+@@ -173,6 +180,177 @@ export default class RPCServer extends EventEmitter {
+         }
+         this.emit('link', args, deep_callback);
+         break;
++
++      case 'AUTHORIZE': {
++        socket.send?.({
++          cmd,
++          data: { code: 'arrpc-ok' },
++          evt: null,
++          nonce
++        });
++        break;
++      }
++
++      case 'AUTHENTICATE': {
++        socket.send?.({
++          cmd,
++          data: { access_token: args?.access_token ?? null, user: mockUser },
++          evt: null,
++          nonce
++        });
++        break;
++      }
++
++      case 'SET_VOICE_SETTINGS': {
++        const callback = (err, data = {}) => {
++          socket.send?.({
++            cmd,
++            data: err ? { message: String(err) } : data,
++            evt: err ? 'ERROR' : null,
++            nonce
++          });
++
++          if (!err && data) this.dispatchVoiceSettings(data);
++        };
++
++        return this.emit('voice-settings-set', args ?? {}, callback);
++      }
++
++      case 'GET_VOICE_SETTINGS': {
++        const callback = (err, data = {}) => socket.send?.({
++          cmd,
++          data: err ? { message: String(err) } : data,
++          evt: err ? 'ERROR' : null,
++          nonce
++        });
++
++        return this.emit('voice-settings-get', callback);
++      }
++
++      case 'GET_SELECTED_VOICE_CHANNEL': {
++        const callback = (err, data = {}) => socket.send?.({
++          cmd,
++          data: err ? { message: String(err) } : data,
++          evt: err ? 'ERROR' : null,
++          nonce
++        });
++
++        return this.emit('voice-channel-get', callback);
++      }
++
++      case 'SUBSCRIBE': {
++        const eventName = evt ?? args?.evt ?? args?.event;
++
++        if (eventName === 'VOICE_SETTINGS_UPDATE') {
++          this.voiceSettingsSubscribers.add(socket);
++
++          socket.send?.({ cmd, data: null, evt: null, nonce });
++
++          this.emit('voice-settings-get', (err, data) => {
++            if (!err && data) this.dispatchVoiceSettings(data, socket);
++          });
++          break;
++        }
++
++        if (eventName === 'VOICE_STATE_UPDATE') {
++          this.voiceStateSubscribers.add(socket);
++
++          socket.send?.({ cmd, data: null, evt: null, nonce });
++
++          this.emit('voice-settings-get', (err, data) => {
++            if (!err && data) {
++              const state = this.toVoiceState(data);
++              this.dispatchVoiceState(state, socket);
++            }
++          });
++          break;
++        }
++
++        socket.send?.({ cmd, data: null, evt: null, nonce });
++        break;
++      }
++
++      case 'UNSUBSCRIBE': {
++        const eventName = evt ?? args?.evt ?? args?.event;
++        if (eventName === 'VOICE_SETTINGS_UPDATE') this.voiceSettingsSubscribers.delete(socket);
++        if (eventName === 'VOICE_STATE_UPDATE') this.voiceStateSubscribers.delete(socket);
++        socket.send?.({ cmd, data: null, evt: null, nonce });
++        break;
++      }
++    }
++  }
++
++  dispatchVoiceSettings(data, target) {
++    const payload = {
++      cmd: 'DISPATCH',
++      data,
++      evt: 'VOICE_SETTINGS_UPDATE',
++      nonce: null
++    };
++
++    if (target) target.send?.(payload);
++
++    for (const sock of this.voiceSettingsSubscribers) {
++      sock.send?.(payload);
++    }
++
++    this.dispatchVoiceState(data);
++  }
++
++  toVoiceState(data) {
++    const source = data.voice_state ?? data;
++    return {
++      mute: source.self_mute ?? source.mute ?? false,
++      deaf: source.self_deaf ?? source.deaf ?? false,
++      self_mute: source.self_mute ?? source.mute ?? false,
++      self_deaf: source.self_deaf ?? source.deaf ?? false,
++      channel_id: source.channel_id ?? null,
++      guild_id: source.guild_id ?? null,
++      user_id: source.user_id ?? null,
++      session_id: source.session_id ?? 'arrpc-session',
++      suppress: source.suppress ?? false,
++      self_stream: source.self_stream ?? false,
++      self_video: source.self_video ?? false,
++      request_to_speak_timestamp: source.request_to_speak_timestamp ?? null,
++      voice_state: {
++        channel_id: source.channel_id ?? null,
++        guild_id: source.guild_id ?? null,
++        user_id: source.user_id ?? null,
++        mute: source.self_mute ?? source.mute ?? false,
++        deaf: source.self_deaf ?? source.deaf ?? false,
++        self_mute: source.self_mute ?? source.mute ?? false,
++        self_deaf: source.self_deaf ?? source.deaf ?? false,
++        session_id: source.session_id ?? 'arrpc-session',
++        suppress: source.suppress ?? false,
++        self_stream: source.self_stream ?? false,
++        self_video: source.self_video ?? false,
++        request_to_speak_timestamp: source.request_to_speak_timestamp ?? null
++      }
++    };
++  }
++
++  dispatchVoiceState(data, target) {
++    const state = this.toVoiceState(data);
++    const payload = {
++      cmd: 'DISPATCH',
++      data: state,
++      evt: 'VOICE_STATE_UPDATE',
++      nonce: null
++    };
++
++    if (target) target.send?.(payload);
++    for (const sock of this.voiceStateSubscribers) {
++      sock.send?.(payload);
++    }
++    if (this.ipc?.server?.connections) {
++      for (const sock of this.ipc.server.connections ?? []) {
++        sock.send?.(payload);
++      }
++    }
++    if (this.ws?.wss?.clients) {
++      for (const sock of this.ws.wss.clients) {
++        sock.send?.(payload);
++      }
+     }
+   }
+ }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   arrpc@3.5.0:
-    hash: 4313fe844324a52ef0453078a86f5d1ee2d4f406331201211020d9fa243323c4
+    hash: 71731f23c3ebace6210db342b7e98da49bfab7115cff16858267749a9ffb6175
     path: patches/arrpc@3.5.0.patch
   electron-updater:
     hash: 080505564abb2ebbda932bbf8fe91540c74dd905de994888d52ffce6f882f887
@@ -18,7 +18,7 @@ importers:
     dependencies:
       arrpc:
         specifier: github:OpenAsar/arrpc#2234e9c9111f4c42ebcc3aa6a2215bfd979eef77
-        version: https://codeload.github.com/OpenAsar/arrpc/tar.gz/2234e9c9111f4c42ebcc3aa6a2215bfd979eef77(patch_hash=4313fe844324a52ef0453078a86f5d1ee2d4f406331201211020d9fa243323c4)
+        version: https://codeload.github.com/OpenAsar/arrpc/tar.gz/2234e9c9111f4c42ebcc3aa6a2215bfd979eef77(patch_hash=71731f23c3ebace6210db342b7e98da49bfab7115cff16858267749a9ffb6175)
       electron-updater:
         specifier: ^6.6.2
         version: 6.6.2(patch_hash=080505564abb2ebbda932bbf8fe91540c74dd905de994888d52ffce6f882f887)
@@ -4042,7 +4042,7 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
-  arrpc@https://codeload.github.com/OpenAsar/arrpc/tar.gz/2234e9c9111f4c42ebcc3aa6a2215bfd979eef77(patch_hash=4313fe844324a52ef0453078a86f5d1ee2d4f406331201211020d9fa243323c4):
+  arrpc@https://codeload.github.com/OpenAsar/arrpc/tar.gz/2234e9c9111f4c42ebcc3aa6a2215bfd979eef77(patch_hash=71731f23c3ebace6210db342b7e98da49bfab7115cff16858267749a9ffb6175):
     dependencies:
       ws: 8.18.0
     transitivePeerDependencies:

--- a/src/main/arrpc/types.ts
+++ b/src/main/arrpc/types.ts
@@ -4,8 +4,35 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-export type ArRpcEvent = ArRpcActivityEvent | ArRpcInviteEvent | ArRpcLinkEvent;
-export type ArRpcHostEvent = ArRpcHostAckInviteEvent | ArRpcHostAckLinkEvent;
+export type ArRpcEvent =
+    | ArRpcActivityEvent
+    | ArRpcInviteEvent
+    | ArRpcLinkEvent
+    | ArRpcVoiceSettingsSetEvent
+    | ArRpcVoiceSettingsGetEvent
+    | ArRpcVoiceChannelGetEvent;
+export type ArRpcHostEvent =
+    | ArRpcHostAckInviteEvent
+    | ArRpcHostAckLinkEvent
+    | ArRpcHostAckVoiceSettingsEvent
+    | ArRpcHostAckVoiceChannelEvent
+    | ArRpcHostVoiceSettingsDispatchEvent;
+
+export interface VoiceSettingsState {
+    mute: boolean;
+    deaf: boolean;
+    self_mute?: boolean;
+    self_deaf?: boolean;
+    channel_id?: string | null;
+    guild_id?: string | null;
+    user_id?: string;
+    voice_state?: any;
+    session_id?: string;
+    suppress?: boolean;
+    self_stream?: boolean;
+    self_video?: boolean;
+    request_to_speak_timestamp?: null;
+}
 
 export interface ArRpcActivityEvent {
     type: "activity";
@@ -25,6 +52,22 @@ export interface ArRpcLinkEvent {
     data: any;
 }
 
+export interface ArRpcVoiceSettingsSetEvent {
+    type: "voice-set";
+    nonce: string;
+    data: Partial<VoiceSettingsState>;
+}
+
+export interface ArRpcVoiceSettingsGetEvent {
+    type: "voice-get";
+    nonce: string;
+}
+
+export interface ArRpcVoiceChannelGetEvent {
+    type: "voice-channel-get";
+    nonce: string;
+}
+
 export interface ArRpcHostAckInviteEvent {
     type: "ack-invite";
     nonce: string;
@@ -35,4 +78,21 @@ export interface ArRpcHostAckLinkEvent {
     type: "ack-link";
     nonce: string;
     data: boolean;
+}
+
+export interface ArRpcHostAckVoiceSettingsEvent {
+    type: "ack-voice-set" | "ack-voice-get";
+    nonce: string;
+    data: VoiceSettingsState | { error: string };
+}
+
+export interface ArRpcHostAckVoiceChannelEvent {
+    type: "ack-voice-channel";
+    nonce: string;
+    data: { channel_id: string | null; guild_id?: string | null } | { error: string };
+}
+
+export interface ArRpcHostVoiceSettingsDispatchEvent {
+    type: "voice-settings-update";
+    data: VoiceSettingsState;
 }

--- a/src/preload/VesktopNative.ts
+++ b/src/preload/VesktopNative.ts
@@ -9,7 +9,7 @@ import { ipcRenderer } from "electron";
 import { IpcMessage, IpcResponse } from "main/ipcCommands";
 import type { Settings } from "shared/settings";
 
-import { IpcEvents } from "../shared/IpcEvents";
+import { IpcCommands, IpcEvents } from "../shared/IpcEvents";
 import { invoke, sendSync } from "./typedIpc";
 
 type SpellCheckerResultCallback = (word: string, suggestions: string[]) => void;
@@ -93,6 +93,10 @@ export const VesktopNative = {
     debug: {
         launchGpu: () => invoke<void>(IpcEvents.DEBUG_LAUNCH_GPU),
         launchWebrtcInternals: () => invoke<void>(IpcEvents.DEBUG_LAUNCH_WEBRTC_INTERNALS)
+    },
+    rpcVoice: {
+        notifyState: (state: { mute: boolean; deaf: boolean }) =>
+            ipcRenderer.send(IpcCommands.RPC_VOICE_STATE_UPDATE, state)
     },
     commands: {
         onCommand(cb: (message: IpcMessage) => void) {

--- a/src/renderer/arrpc.ts
+++ b/src/renderer/arrpc.ts
@@ -14,9 +14,161 @@ import { Settings } from "./settings";
 
 const logger = new Logger("VesktopRPC", "#5865f2");
 const StreamerModeStore = findStoreLazy("StreamerModeStore");
+const MediaEngineStore = findStoreLazy("MediaEngineStore");
+const RTCConnectionStore = findStoreLazy("RTCConnectionStore");
+const UserStore = findStoreLazy("UserStore");
+const VoiceToggleActions = findLazy(
+    m => typeof m?.toggleSelfMute === "function" && typeof m?.toggleSelfDeaf === "function"
+);
 
 const arRPC = Vencord.Plugins.plugins["WebRichPresence (arRPC)"] as any as {
     handleEvent(e: MessageEvent): void;
+};
+
+type VoiceState = { mute: boolean; deaf: boolean };
+
+let lastVoiceState: VoiceState = { mute: false, deaf: false };
+
+const getVoiceState = (): VoiceState => ({
+    mute:
+        MediaEngineStore?.isSelfMute?.() ??
+        MediaEngineStore?.isLocalMute?.() ??
+        RTCConnectionStore?.isSelfMute?.() ??
+        lastVoiceState.mute ??
+        false,
+    deaf: MediaEngineStore?.isSelfDeaf?.() ?? RTCConnectionStore?.isSelfDeaf?.() ?? lastVoiceState.deaf ?? false
+});
+
+type VoiceStatePayload = VoiceState & {
+    self_mute: boolean;
+    self_deaf: boolean;
+    channel_id: string | null;
+    guild_id: string | null;
+    user_id: string;
+    voice_state: any;
+    session_id: string;
+    suppress: boolean;
+    self_stream: boolean;
+    self_video: boolean;
+    request_to_speak_timestamp: null;
+};
+
+const sendVoiceStateUpdate = (state: VoiceState) => {
+    lastVoiceState = state;
+    const { channel_id, guild_id } = getSelectedVoiceChannel();
+    const user_id = UserStore?.getCurrentUser?.()?.id ?? "0";
+
+    const payload: VoiceStatePayload = {
+        ...state,
+        self_mute: state.mute,
+        self_deaf: state.deaf,
+        channel_id,
+        guild_id,
+        user_id,
+        voice_state: {
+            channel_id,
+            guild_id,
+            user_id,
+            mute: state.mute,
+            deaf: state.deaf,
+            self_mute: state.mute,
+            self_deaf: state.deaf,
+            session_id: "arrpc-session",
+            suppress: false,
+            self_stream: false,
+            self_video: false,
+            request_to_speak_timestamp: null
+        },
+        session_id: "arrpc-session",
+        suppress: false,
+        self_stream: false,
+        self_video: false,
+        request_to_speak_timestamp: null
+    };
+    VesktopNative.rpcVoice?.notifyState?.(payload);
+};
+
+const refreshVoiceState = () => sendVoiceStateUpdate(getVoiceState());
+
+onceReady.then(() => {
+    refreshVoiceState();
+    MediaEngineStore?.addChangeListener?.(refreshVoiceState);
+    RTCConnectionStore?.addChangeListener?.(refreshVoiceState);
+});
+
+const sleep = (ms: number) => new Promise(res => setTimeout(res, ms));
+
+type PartialVoice = Partial<VoiceState>;
+
+type VoicePatch = Omit<Partial<VoiceState>, "mute" | "deaf"> & {
+    toggle?: boolean;
+    toggle_mute?: boolean;
+    toggle_deaf?: boolean;
+    mute?: boolean | "toggle";
+    deaf?: boolean | "toggle";
+};
+
+async function applyVoiceSettings(partial: VoicePatch) {
+    if (!Settings.store.arRPC) throw new Error("arRPC is disabled in settings");
+    await onceReady;
+    if (!VoiceToggleActions) throw new Error("Unable to locate Discord voice toggle actions");
+
+    const current = getVoiceState();
+
+    const wantToggleMute = partial.toggle === true || partial.toggle_mute === true || partial.mute === "toggle";
+    const wantToggleDeaf = partial.toggle === true || partial.toggle_deaf === true || partial.deaf === "toggle";
+
+    let targetMute = wantToggleMute ? !current.mute : typeof partial.mute === "boolean" ? partial.mute : current.mute;
+    const targetDeaf = wantToggleDeaf ? !current.deaf : typeof partial.deaf === "boolean" ? partial.deaf : current.deaf;
+
+    // If caller explicitly set deaf and did not mention mute, map mute to match deaf (deafen=>mute, undeafen=>unmute).
+    if (typeof partial.deaf === "boolean" && partial.mute === undefined) {
+        targetMute = partial.deaf;
+    }
+
+    // Simple rule: deafen implies mute. Undeafen leaves mute as requested (defaults handled above).
+    if (targetDeaf && !targetMute) targetMute = true;
+
+    console.log("[arRPC voice] request", partial, "current", current, "target", { targetMute, targetDeaf });
+
+    const setState = async (key: "mute" | "deaf", desired: boolean) => {
+        let state = getVoiceState();
+        if (state[key] === desired) return state;
+        for (let attempt = 1; attempt <= 3; attempt++) {
+            (key === "mute" ? VoiceToggleActions.toggleSelfMute : VoiceToggleActions.toggleSelfDeaf)();
+            await sleep(100);
+            state = getVoiceState();
+            console.log("[arRPC voice] attempt", attempt, key, "now", state[key], "want", desired);
+            if (state[key] === desired) return state;
+        }
+        return state;
+    };
+
+    let latest = current;
+    if (targetDeaf !== latest.deaf) latest = await setState("deaf", targetDeaf);
+    if (targetMute !== latest.mute) latest = await setState("mute", targetMute);
+
+    lastVoiceState = latest;
+    console.log("[arRPC voice] final state", latest);
+    sendVoiceStateUpdate(latest);
+    return latest;
+}
+
+const getSelectedVoiceChannel = () => {
+    const channelId =
+        RTCConnectionStore?.getChannelId?.() ??
+        RTCConnectionStore?.getConnectedChannelId?.() ??
+        RTCConnectionStore?.getActiveChannelId?.() ??
+        RTCConnectionStore?.getCurrentClientVoiceChannelId?.() ??
+        null;
+
+    const guildId =
+        RTCConnectionStore?.getGuildId?.() ??
+        RTCConnectionStore?.getConnectedGuildId?.() ??
+        RTCConnectionStore?.getGuildIdForChannel?.(channelId) ??
+        null;
+
+    return { channel_id: channelId ?? null, guild_id: guildId ?? null };
 };
 
 onIpcCommand(IpcCommands.RPC_ACTIVITY, async jsonData => {
@@ -65,4 +217,22 @@ onIpcCommand(IpcCommands.RPC_DEEP_LINK, async data => {
         logger.error("Failed to open deep link:", err);
         return false;
     }
+});
+
+onIpcCommand(IpcCommands.RPC_SET_VOICE_SETTINGS, async data => {
+    return applyVoiceSettings(data ?? {});
+});
+
+onIpcCommand(IpcCommands.RPC_GET_VOICE_SETTINGS, async () => {
+    if (!Settings.store.arRPC) throw new Error("arRPC is disabled in settings");
+
+    await onceReady;
+    return getVoiceState();
+});
+
+onIpcCommand(IpcCommands.RPC_GET_SELECTED_VOICE_CHANNEL, async () => {
+    if (!Settings.store.arRPC) throw new Error("arRPC is disabled in settings");
+
+    await onceReady;
+    return getSelectedVoiceChannel();
 });

--- a/src/shared/IpcEvents.ts
+++ b/src/shared/IpcEvents.ts
@@ -74,6 +74,10 @@ export const enum IpcCommands {
     RPC_ACTIVITY = "rpc:activity",
     RPC_INVITE = "rpc:invite",
     RPC_DEEP_LINK = "rpc:link",
+    RPC_SET_VOICE_SETTINGS = "rpc:voice:set",
+    RPC_GET_VOICE_SETTINGS = "rpc:voice:get",
+    RPC_GET_SELECTED_VOICE_CHANNEL = "rpc:voice:getSelectedChannel",
+    RPC_VOICE_STATE_UPDATE = "rpc:voice:update",
 
     NAVIGATE_SETTINGS = "navigate:settings",
 


### PR DESCRIPTION
- Added IPC commands for setting and getting voice settings and selected voice channel.
- Introduced voice state updates and dispatching mechanisms in the server and worker.
- Updated pnpm-lock.yaml with new patch hash for arrpc.

The intention here was to get StreamController (Linux Stream deck software) working with Vesktop. Specifically, using the Discord plugin and the mute/deafen buttons. 

The initial mute startup state doesn't get communicated, but you can just join a call or unmute to fix.