### PR TITLE
fix: disable WaylandWpColorManagerV1

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -28,6 +28,8 @@ process.env.VENCORD_USER_DATA_DIR = DATA_DIR;
 
 const isLinux = process.platform === "linux";
 
+const isWayland = isLinux && (process.env.XDG_SESSION_TYPE === "wayland" || !!process.env.WAYLAND_DISPLAY);
+
 export let enableHardwareAcceleration = true;
 
 function init() {
@@ -81,6 +83,10 @@ function init() {
     if (isLinux) {
         // Support TTS on Linux using https://wiki.archlinux.org/title/Speech_dispatcher
         app.commandLine.appendSwitch("enable-speech-dispatcher");
+    }
+
+    if (isWayland) {
+        disabledFeatures.add("WaylandWpColorManagerV1");
     }
 
     disabledFeatures.forEach(feat => enabledFeatures.delete(feat));


### PR DESCRIPTION
This fixes this color issue that occurs on Wayland:

https://github.com/user-attachments/assets/a8908888-d9a6-440b-a79b-3a5a8aa82bee

Linked issue: https://github.com/electron/electron/issues/49566
