### PR TITLE
add condition to isDeckGameMode to fix nested desktop usage

### DIFF
--- a/src/main/utils/steamOS.ts
+++ b/src/main/utils/steamOS.ts
@@ -19,7 +19,10 @@ const numberRegex = /^[0-9]*$/;
 
 let steamPipeQueue = Promise.resolve();
 
-export const isDeckGameMode = process.env.SteamOS === "1" && process.env.SteamGamepadUI === "1";
+export const isDeckGameMode =
+    process.env.SteamOS === "1" &&
+    process.env.SteamGamepadUI === "1" &&
+    process.env.XDG_CURRENT_DESKTOP === "gamescope";
 
 export function applyDeckKeyboardFix() {
     if (!isDeckGameMode) return;


### PR DESCRIPTION
Fixes vencord taking over the nested desktop session, as described in [this discord message](https://discord.com/channels/1015060230222131221/1345457031426871417/1483930293424357566).

when running `npm test`, the linter requested the statement be split into multiple lines, so I have done so.

While testing, I noticed that the `XDG_CURRENT_DESKTOP` variable is actually also set by gamescope, so I changed the discussed check to pass on `XDG_CURRENT_DESKTOP === "gamescope"`. Any desktop environment launched within gamescope should change this variable, so this check should fix the issue for any DE launched from game mode.

I had considered that it may cover more scenarios if `XDG_CURRENT_DESKTOP` was used by itself to set the game mode variable, but since gamescope can be used without the steam client, not all features enabled by this variable make sense in those scenarios, so it seems best to include all 3 checks for the most correct behaviour.