### PR TITLE
fix ipc handleSync + spellcheck languages

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -128,8 +128,8 @@ handle(IpcEvents.MAXIMIZE, (e, key?: string) => {
     }
 });
 
-handleSync(IpcEvents.SPELLCHECK_GET_AVAILABLE_LANGUAGES, e => {
-    e.returnValue = session.defaultSession.availableSpellCheckerLanguages;
+handleSync(IpcEvents.SPELLCHECK_GET_AVAILABLE_LANGUAGES, () => {
+    return session.defaultSession.availableSpellCheckerLanguages;
 });
 
 handle(IpcEvents.SPELLCHECK_REPLACE_MISSPELLING, (e, word: string) => {

--- a/src/main/utils/ipcWrappers.ts
+++ b/src/main/utils/ipcWrappers.ts
@@ -28,7 +28,10 @@ export function validateSender(frame: WebFrameMain | null, event: string) {
 export function handleSync(event: IpcEvents | UpdaterIpcEvents, cb: (e: IpcMainEvent, ...args: any[]) => any) {
     ipcMain.on(event, (e, ...args) => {
         validateSender(e.senderFrame, event);
-        e.returnValue = cb(e, ...args);
+        const result = cb(e, ...args);
+        if (e.returnValue === undefined) {
+            e.returnValue = result;
+        }
     });
 }
 


### PR DESCRIPTION
fixes handleSync overriding e.returnValue in some cases

also updates the spellcheck languages handler to return the value
instead of mutating the event, which could lead to undefined on the renderer side