### PR TITLE
Fix Linux screenshare state drift and sender recovery during viewer attach/rejoin

### DIFF
--- a/src/renderer/components/ScreenSharePicker.tsx
+++ b/src/renderer/components/ScreenSharePicker.tsx
@@ -42,6 +42,14 @@ import { SimpleErrorBoundary } from "./SimpleErrorBoundary";
 
 const StreamResolutions = ["480", "720", "1080", "1440", "2160"] as const;
 const StreamFps = ["15", "30", "60"] as const;
+export const screenShareBitrateMin = 500000;
+export const screenShareBitrateMaxFloor = 8000000;
+export const screenShareBitrateTarget = 600000;
+const screenSharePixelCountGuardKey = "__vesktopScreenSharePixelCountGuard";
+const screenShareVideoStreamParametersGuardKey = "__vesktopScreenShareVideoStreamParametersGuard";
+const screenShareMaxResolutionGuardKey = "__vesktopScreenShareMaxResolutionGuard";
+const screenShareVideoStreamParameterListGuardKey = "__vesktopScreenShareVideoStreamParameterListGuard";
+const screenShareSyncDelaysMs = [0, 10, 50, 100, 250, 500, 1000];
 
 const cl = classNameFactory("vcd-screen-picker-");
 
@@ -75,9 +83,436 @@ interface Source {
     url: string;
 }
 
+interface ScreenShareProfile {
+    frameRate: number;
+    height: number;
+    width: number;
+    pixelCount: number;
+}
+
+interface ScreenShareBitrateProfile {
+    min: number;
+    target: number;
+    max: number;
+}
+
+export interface ScreenShareVideoStreamParameters {
+    maxBitrate?: number;
+    maxFrameRate?: number;
+    maxPixelCount?: number;
+    minBitrate?: number;
+    targetBitrate?: number;
+    maxResolution?: {
+        type?: string;
+        width?: number;
+        height?: number;
+        [key: string]: unknown;
+    };
+    [key: string]: unknown;
+}
+
+interface MediaEngineConnectionLike {
+    streamUserId?: string;
+    input?: {
+        desktop?: {
+            stream?: {
+                getVideoTracks?: () => MediaStreamTrack[];
+            };
+        };
+    };
+    videoStreamParameters?: Array<ScreenShareVideoStreamParameters | undefined>;
+}
+
 export let currentSettings: StreamSettings | null = null;
 
 const logger = new Logger("VesktopScreenShare");
+let screenShareParameterSyncSequence = 0;
+
+function getCurrentUserMediaEngineConnections() {
+    try {
+        const currentUserId = UserStore.getCurrentUser()?.id;
+        if (!currentUserId) {
+            return [] as MediaEngineConnectionLike[];
+        }
+
+        return [...MediaEngineStore.getMediaEngine().connections].filter(
+            candidate => candidate.streamUserId === currentUserId
+        ) as MediaEngineConnectionLike[];
+    } catch (error) {
+        logger.error("Failed to enumerate media engine connections for screenshare sync.", error);
+        return [];
+    }
+}
+
+function hasDesktopVideoTrack(connection: MediaEngineConnectionLike) {
+    return Boolean(connection.input?.desktop?.stream?.getVideoTracks?.().some(track => track.kind === "video"));
+}
+
+function getCurrentUserScreenShareVideoStreamParameterTargets() {
+    const connections = getCurrentUserMediaEngineConnections();
+    if (!connections.length) {
+        return [];
+    }
+
+    const preferredConnections = connections.filter(hasDesktopVideoTrack);
+    return preferredConnections.length ? preferredConnections : connections.slice(0, 1);
+}
+
+export function getSelectedScreenShareProfile(): ScreenShareProfile {
+    const { screenshareQuality } = State.store;
+    const frameRate = Number(screenshareQuality?.frameRate ?? 30);
+    const height = Number(screenshareQuality?.resolution ?? 720);
+    const width = Math.round(height * (16 / 9));
+
+    return {
+        frameRate,
+        height,
+        width,
+        pixelCount: height * width
+    };
+}
+
+function normalizeScreenShareBitrate(value: unknown) {
+    const bitrate = Number(value);
+    return Number.isFinite(bitrate) && bitrate > 0 ? Math.round(bitrate) : void 0;
+}
+
+function applyScreenShareBitrateFloor(value: number) {
+    return Math.max(screenShareBitrateMin, Math.round(value));
+}
+
+export function getSelectedScreenShareBitrateProfile(
+    profile: ScreenShareProfile = getSelectedScreenShareProfile()
+): ScreenShareBitrateProfile {
+    let min = screenShareBitrateMin;
+    let target = screenShareBitrateTarget;
+
+    if (profile.height >= 2160) {
+        min = 4000000;
+        target = 6000000;
+    } else if (profile.height >= 1440) {
+        min = 3000000;
+        target = 5000000;
+    } else if (profile.height >= 1080) {
+        min = 2000000;
+        target = 3500000;
+    } else if (profile.height >= 720) {
+        min = 1200000;
+        target = 2000000;
+    } else {
+        min = 700000;
+        target = 1000000;
+    }
+
+    if (profile.frameRate >= 60) {
+        min = Math.round(min * 1.25);
+        target = Math.round(target * 1.25);
+    } else if (profile.frameRate <= 15) {
+        min = Math.round(min * 0.9);
+        target = Math.round(target * 0.9);
+    }
+
+    min = applyScreenShareBitrateFloor(min);
+    target = applyScreenShareBitrateFloor(Math.max(target, min));
+
+    return {
+        min,
+        target,
+        max: screenShareBitrateMaxFloor
+    };
+}
+
+function getScreenShareBitrateValueAtLeast(value: unknown, floor: number) {
+    return normalizeScreenShareBitrate(value) ?? applyScreenShareBitrateFloor(floor);
+}
+
+function installScreenSharePixelCountGuard(videoStreamParameters: ScreenShareVideoStreamParameters) {
+    const guardedStreamParameters = videoStreamParameters as Record<string, unknown>;
+    if (guardedStreamParameters[screenSharePixelCountGuardKey]) {
+        return;
+    }
+
+    Object.defineProperty(videoStreamParameters, "maxPixelCount", {
+        configurable: true,
+        enumerable: true,
+        get() {
+            return getSelectedScreenShareProfile().pixelCount;
+        },
+        set() {
+            // Always reflect the currently selected profile on reads.
+        }
+    });
+
+    Object.defineProperty(videoStreamParameters, screenSharePixelCountGuardKey, {
+        configurable: false,
+        enumerable: false,
+        value: true,
+        writable: false
+    });
+}
+
+function installScreenShareMaxResolutionGuard(
+    maxResolution: ScreenShareVideoStreamParameters["maxResolution"]
+): NonNullable<ScreenShareVideoStreamParameters["maxResolution"]> {
+    const guardedMaxResolution = (
+        typeof maxResolution === "object" && maxResolution !== null ? maxResolution : {}
+    ) as NonNullable<ScreenShareVideoStreamParameters["maxResolution"]> & Record<string, unknown>;
+
+    if (guardedMaxResolution[screenShareMaxResolutionGuardKey]) {
+        return guardedMaxResolution;
+    }
+
+    Object.defineProperty(guardedMaxResolution, "type", {
+        configurable: true,
+        enumerable: true,
+        get() {
+            return "fixed";
+        },
+        set() {
+            // Always reflect a fixed resolution profile on reads.
+        }
+    });
+
+    Object.defineProperty(guardedMaxResolution, "width", {
+        configurable: true,
+        enumerable: true,
+        get() {
+            return getSelectedScreenShareProfile().width;
+        },
+        set() {
+            // Always reflect the currently selected profile on reads.
+        }
+    });
+
+    Object.defineProperty(guardedMaxResolution, "height", {
+        configurable: true,
+        enumerable: true,
+        get() {
+            return getSelectedScreenShareProfile().height;
+        },
+        set() {
+            // Always reflect the currently selected profile on reads.
+        }
+    });
+
+    Object.defineProperty(guardedMaxResolution, screenShareMaxResolutionGuardKey, {
+        configurable: false,
+        enumerable: false,
+        value: true,
+        writable: false
+    });
+
+    return guardedMaxResolution;
+}
+
+function installScreenShareVideoStreamParameterGuards(videoStreamParameters: ScreenShareVideoStreamParameters) {
+    const guardedStreamParameters = videoStreamParameters as Record<string, unknown>;
+    if (guardedStreamParameters[screenShareVideoStreamParametersGuardKey]) {
+        return;
+    }
+
+    let maxResolution = installScreenShareMaxResolutionGuard(videoStreamParameters.maxResolution);
+    let maxBitrate = normalizeScreenShareBitrate(videoStreamParameters.maxBitrate);
+    let minBitrate = normalizeScreenShareBitrate(videoStreamParameters.minBitrate);
+    let targetBitrate = normalizeScreenShareBitrate(videoStreamParameters.targetBitrate);
+
+    installScreenSharePixelCountGuard(videoStreamParameters);
+
+    Object.defineProperty(videoStreamParameters, "maxBitrate", {
+        configurable: true,
+        enumerable: true,
+        get() {
+            return getScreenShareBitrateValueAtLeast(maxBitrate, getSelectedScreenShareBitrateProfile().max);
+        },
+        set(value) {
+            maxBitrate = normalizeScreenShareBitrate(value);
+        }
+    });
+
+    Object.defineProperty(videoStreamParameters, "minBitrate", {
+        configurable: true,
+        enumerable: true,
+        get() {
+            return getScreenShareBitrateValueAtLeast(minBitrate, getSelectedScreenShareBitrateProfile().min);
+        },
+        set(value) {
+            minBitrate = normalizeScreenShareBitrate(value);
+        }
+    });
+
+    Object.defineProperty(videoStreamParameters, "targetBitrate", {
+        configurable: true,
+        enumerable: true,
+        get() {
+            return getScreenShareBitrateValueAtLeast(targetBitrate, getSelectedScreenShareBitrateProfile().target);
+        },
+        set(value) {
+            targetBitrate = normalizeScreenShareBitrate(value);
+        }
+    });
+
+    Object.defineProperty(videoStreamParameters, "maxFrameRate", {
+        configurable: true,
+        enumerable: true,
+        get() {
+            return getSelectedScreenShareProfile().frameRate;
+        },
+        set() {
+            // Always reflect the currently selected profile on reads.
+        }
+    });
+
+    Object.defineProperty(videoStreamParameters, "maxResolution", {
+        configurable: true,
+        enumerable: true,
+        get() {
+            return maxResolution;
+        },
+        set(value) {
+            maxResolution = installScreenShareMaxResolutionGuard(value);
+            maxResolution.type = "fixed";
+            maxResolution.width = getSelectedScreenShareProfile().width;
+            maxResolution.height = getSelectedScreenShareProfile().height;
+        }
+    });
+
+    Object.defineProperty(videoStreamParameters, screenShareVideoStreamParametersGuardKey, {
+        configurable: false,
+        enumerable: false,
+        value: true,
+        writable: false
+    });
+}
+
+function installScreenShareVideoStreamParameterListGuard(
+    videoStreamParameters: Array<ScreenShareVideoStreamParameters | undefined> | undefined
+) {
+    if (!Array.isArray(videoStreamParameters)) {
+        return videoStreamParameters;
+    }
+
+    const guardedParameterList = videoStreamParameters as Array<ScreenShareVideoStreamParameters | undefined> &
+        Record<string, unknown>;
+
+    if (guardedParameterList[screenShareVideoStreamParameterListGuardKey]) {
+        const currentPrimaryParameters = guardedParameterList[0];
+        if (currentPrimaryParameters) {
+            installScreenShareVideoStreamParameterGuards(currentPrimaryParameters);
+        }
+
+        return videoStreamParameters;
+    }
+
+    let primaryParameters = guardedParameterList[0];
+    if (primaryParameters) {
+        installScreenShareVideoStreamParameterGuards(primaryParameters);
+    }
+
+    Object.defineProperty(guardedParameterList, "0", {
+        configurable: true,
+        enumerable: true,
+        get() {
+            return primaryParameters;
+        },
+        set(value: ScreenShareVideoStreamParameters | undefined) {
+            if (value) {
+                installScreenShareVideoStreamParameterGuards(value);
+            }
+
+            primaryParameters = value;
+        }
+    });
+
+    Object.defineProperty(guardedParameterList, screenShareVideoStreamParameterListGuardKey, {
+        configurable: false,
+        enumerable: false,
+        value: true,
+        writable: false
+    });
+
+    return videoStreamParameters;
+}
+
+export function getScreenShareConnectionVideoStreamParameters(
+    connection:
+        | {
+              videoStreamParameters?: Array<ScreenShareVideoStreamParameters | undefined>;
+          }
+        | null
+        | undefined
+) {
+    const guardedParameterList = installScreenShareVideoStreamParameterListGuard(connection?.videoStreamParameters);
+    const currentPrimaryParameters = guardedParameterList?.[0];
+
+    if (currentPrimaryParameters) {
+        installScreenShareVideoStreamParameterGuards(currentPrimaryParameters);
+    }
+
+    return currentPrimaryParameters;
+}
+
+export function syncSelectedScreenShareVideoStreamParameters(
+    videoStreamParameters: ScreenShareVideoStreamParameters | null | undefined
+) {
+    if (!videoStreamParameters) {
+        return;
+    }
+
+    installScreenShareVideoStreamParameterGuards(videoStreamParameters);
+
+    const profile = getSelectedScreenShareProfile();
+    const bitrateProfile = getSelectedScreenShareBitrateProfile(profile);
+
+    videoStreamParameters.maxBitrate = getScreenShareBitrateValueAtLeast(
+        videoStreamParameters.maxBitrate,
+        bitrateProfile.max
+    );
+    videoStreamParameters.maxFrameRate = profile.frameRate;
+    videoStreamParameters.maxPixelCount = profile.pixelCount;
+    videoStreamParameters.minBitrate = getScreenShareBitrateValueAtLeast(
+        videoStreamParameters.minBitrate,
+        bitrateProfile.min
+    );
+    videoStreamParameters.targetBitrate = getScreenShareBitrateValueAtLeast(
+        videoStreamParameters.targetBitrate,
+        bitrateProfile.target
+    );
+
+    const maxResolution = videoStreamParameters.maxResolution ?? (videoStreamParameters.maxResolution = {});
+    maxResolution.type = "fixed";
+    maxResolution.height = profile.height;
+    maxResolution.width = profile.width;
+}
+
+export function syncCurrentUserScreenShareVideoStreamParameters() {
+    if (!isLinux) {
+        return;
+    }
+
+    for (const connection of getCurrentUserScreenShareVideoStreamParameterTargets()) {
+        syncSelectedScreenShareVideoStreamParameters(getScreenShareConnectionVideoStreamParameters(connection));
+    }
+}
+
+export function scheduleCurrentUserScreenShareVideoStreamParameterSync() {
+    if (!isLinux) {
+        return;
+    }
+
+    const currentSequence = ++screenShareParameterSyncSequence;
+
+    syncCurrentUserScreenShareVideoStreamParameters();
+
+    for (const delayMs of screenShareSyncDelaysMs) {
+        window.setTimeout(() => {
+            if (currentSequence !== screenShareParameterSyncSequence) {
+                return;
+            }
+
+            syncCurrentUserScreenShareVideoStreamParameters();
+        }, delayMs);
+    }
+}
 
 addPatch({
     patches: [
@@ -90,31 +525,29 @@ addPatch({
         }
     ],
     patchStreamQuality(opts: any) {
-        const { screenshareQuality } = State.store;
-        if (!screenshareQuality) return opts;
-
-        const framerate = Number(screenshareQuality.frameRate);
-        const height = Number(screenshareQuality.resolution);
-        const width = Math.round(height * (16 / 9));
+        if (!State.store.screenshareQuality) return opts;
+        const profile = getSelectedScreenShareProfile();
 
         Object.assign(opts, {
-            bitrateMin: 500000,
-            bitrateMax: 8000000,
-            bitrateTarget: 600000
+            // Keep the upstream global bitrate policy stable. Linux-specific
+            // runtime parameter recovery happens in the Linux patch path.
+            bitrateMin: getScreenShareBitrateValueAtLeast(opts?.bitrateMin, screenShareBitrateMin),
+            bitrateMax: getScreenShareBitrateValueAtLeast(opts?.bitrateMax, screenShareBitrateMaxFloor),
+            bitrateTarget: getScreenShareBitrateValueAtLeast(opts?.bitrateTarget, screenShareBitrateTarget)
         });
         if (opts?.encode) {
             Object.assign(opts.encode, {
-                framerate,
-                width,
-                height,
-                pixelCount: height * width
+                framerate: profile.frameRate,
+                width: profile.width,
+                height: profile.height,
+                pixelCount: profile.pixelCount
             });
         }
         Object.assign(opts.capture, {
-            framerate,
-            width,
-            height,
-            pixelCount: height * width
+            framerate: profile.frameRate,
+            width: profile.width,
+            height: profile.height,
+            pixelCount: profile.pixelCount
         });
         return opts;
     }
@@ -747,18 +1180,22 @@ function ModalComponent({
                     onClick={() => {
                         currentSettings = settings;
                         try {
-                            const frameRate = Number(qualitySettings.frameRate);
-                            const height = Number(qualitySettings.resolution);
-                            const width = Math.round(height * (16 / 9));
+                            if (isLinux) {
+                                scheduleCurrentUserScreenShareVideoStreamParameterSync();
+                            } else {
+                                const frameRate = Number(qualitySettings.frameRate);
+                                const height = Number(qualitySettings.resolution);
+                                const width = Math.round(height * (16 / 9));
 
-                            const conn = [...MediaEngineStore.getMediaEngine().connections].find(
-                                connection => connection.streamUserId === UserStore.getCurrentUser().id
-                            );
+                                const conn = [...MediaEngineStore.getMediaEngine().connections].find(
+                                    connection => connection.streamUserId === UserStore.getCurrentUser().id
+                                );
 
-                            if (conn) {
-                                conn.videoStreamParameters[0].maxFrameRate = frameRate;
-                                conn.videoStreamParameters[0].maxResolution.height = height;
-                                conn.videoStreamParameters[0].maxResolution.width = width;
+                                if (conn) {
+                                    conn.videoStreamParameters[0].maxFrameRate = frameRate;
+                                    conn.videoStreamParameters[0].maxResolution.height = height;
+                                    conn.videoStreamParameters[0].maxResolution.width = width;
+                                }
                             }
 
                             submit({
@@ -766,34 +1203,35 @@ function ModalComponent({
                                 ...settings
                             });
 
-                            setTimeout(async () => {
-                                const conn = [...MediaEngineStore.getMediaEngine().connections].find(
-                                    connection => connection.streamUserId === UserStore.getCurrentUser().id
-                                );
-                                if (!conn) return;
+                            if (!isLinux) {
+                                const frameRate = Number(qualitySettings.frameRate);
+                                const height = Number(qualitySettings.resolution);
+                                const width = Math.round(height * (16 / 9));
 
-                                const track = conn.input.stream.getVideoTracks()[0];
-
-                                const constraints = {
-                                    ...track.getConstraints(),
-                                    frameRate: { min: frameRate, ideal: frameRate },
-                                    width: { min: 640, ideal: width, max: width },
-                                    height: { min: 480, ideal: height, max: height },
-                                    advanced: [{ width: width, height: height }],
-                                    resizeMode: "none"
-                                };
-
-                                try {
-                                    await track.applyConstraints(constraints);
-
-                                    logger.info(
-                                        "Applied constraints successfully. New constraints:",
-                                        track.getConstraints()
+                                setTimeout(async () => {
+                                    const conn = [...MediaEngineStore.getMediaEngine().connections].find(
+                                        connection => connection.streamUserId === UserStore.getCurrentUser().id
                                     );
-                                } catch (e) {
-                                    logger.error("Failed to apply constraints.", e);
-                                }
-                            }, 100);
+                                    if (!conn) return;
+
+                                    const track = conn.input.stream.getVideoTracks()[0];
+
+                                    const constraints = {
+                                        ...track.getConstraints(),
+                                        frameRate: { min: frameRate, ideal: frameRate },
+                                        width: { min: 640, ideal: width, max: width },
+                                        height: { min: 480, ideal: height, max: height },
+                                        advanced: [{ width: width, height: height }],
+                                        resizeMode: "none"
+                                    };
+
+                                    try {
+                                        await track.applyConstraints(constraints);
+                                    } catch (error) {
+                                        logger.error("Failed to apply constraints.", error);
+                                    }
+                                }, 100);
+                            }
                         } catch (error) {
                             logger.error("Error while submitting stream.", error);
                         }

--- a/src/renderer/patches/screenShareFixes.ts
+++ b/src/renderer/patches/screenShareFixes.ts
@@ -5,51 +5,1704 @@
  */
 
 import { Logger } from "@vencord/types/utils";
-import { currentSettings } from "renderer/components/ScreenSharePicker";
+import { filters, onceReady, waitFor } from "@vencord/types/webpack";
+import { FluxDispatcher, MediaEngineStore, UserStore } from "@vencord/types/webpack/common";
+import {
+    currentSettings,
+    getScreenShareConnectionVideoStreamParameters,
+    getSelectedScreenShareBitrateProfile,
+    getSelectedScreenShareProfile,
+    scheduleCurrentUserScreenShareVideoStreamParameterSync,
+    type ScreenShareVideoStreamParameters,
+    syncSelectedScreenShareVideoStreamParameters
+} from "renderer/components/ScreenSharePicker";
 import { State } from "renderer/settings";
 import { isLinux } from "renderer/utils";
 
 const logger = new Logger("VesktopStreamFixes");
 
+const screenShareRecoveryCooldownMs = 1000;
+const screenShareTrackConstraintSyncCooldownMs = 1000;
+const screenShareProfileChangeSyncDelaysMs = [0, 10, 50, 100, 250, 500, 1000, 2000];
+const senderParameterSyncRetryDelayMs = 50;
+const viewerAttachRecoveryDelayMs = 1000;
+const viewerRejoinRecoveryDelayMs = 250;
+const audienceRecoveryHealthProbeDelayMs = 300;
+
+const managedScreenShareTracks = new WeakSet<MediaStreamTrack>();
+const detailDisplayTracks = new WeakSet<MediaStreamTrack>();
+const trackLocalConnectionHints = new WeakMap<MediaStreamTrack, MediaConnectionLike>();
+const trackedPeerConnections = new WeakSet<RTCPeerConnection>();
+const trackedScreenSharePeerConnections = new Set<RTCPeerConnection>();
+const senderPeerConnections = new WeakMap<RTCRtpSender, RTCPeerConnection>();
+const senderParameterSyncFailureCounts = new WeakMap<RTCRtpSender, number>();
+const senderParameterSyncTasks = new WeakMap<RTCRtpSender, Promise<void>>();
+const senderParameterSyncPending = new WeakMap<RTCRtpSender, boolean>();
+const trackConstraintSyncTasks = new WeakMap<MediaStreamTrack, Promise<void>>();
+const trackConstraintSyncPending = new WeakMap<MediaStreamTrack, boolean>();
+const trackConstraintSyncPendingRequests = new WeakMap<MediaStreamTrack, PendingTrackConstraintSyncRequest>();
+const recoveryManagedReplaceTrackSenders = new WeakSet<RTCRtpSender>();
+const senderRecoveryStates = new WeakMap<RTCRtpSender, SenderRecoveryState>();
+const trackConstraintSyncAttemptAt = new WeakMap<MediaStreamTrack, number>();
+const directLocalScreenShareSinkWantsPatchedUpdateVideoQuality = new WeakMap<
+    MediaConnectionLike,
+    (...args: unknown[]) => unknown
+>();
+const directScreenShareSinkWantsPropertyPatchStates = new WeakMap<
+    MediaConnectionLike,
+    DirectScreenShareSinkWantsPropertyPatchState
+>();
+let activeDetailTrackSyncSequence = 0;
+let viewerRejoinRecoveryTimer: number | undefined;
+let viewerRejoinRecoverySequence = 0;
+
+interface SenderRecoveryState {
+    inRecovery: boolean;
+    lastRecoveryAt?: number;
+}
+
+interface VideoSenderSnapshot {
+    bytesSent: number;
+    framesEncoded: number;
+    frameWidth?: number;
+    frameHeight?: number;
+    sampledAt: number;
+}
+
+interface MediaConnectionLike {
+    streamUserId?: string;
+    negotiationNeeded?: boolean;
+    handleNegotiationNeeded?: () => void | Promise<void>;
+    localVideoSinkWants?: RemoteVideoSinkWantsLike;
+    remoteVideoSinkWants?: RemoteVideoSinkWantsLike;
+    updateVideoQuality?: (...args: unknown[]) => unknown;
+    input?: {
+        stream?: {
+            getVideoTracks?: () => MediaStreamTrack[];
+        };
+        desktop?: {
+            stream?: MediaStream;
+        };
+        mergeStreams?: () => void;
+    };
+    videoStreamParameters?: Array<ScreenShareVideoStreamParameters | undefined>;
+}
+
+interface ApplicationStreamLike {
+    streamType?: string;
+    guildId?: string | null;
+    channelId?: string;
+    ownerId?: string;
+}
+
+interface ApplicationStreamingStoreLike {
+    addChangeListener?: (listener: () => void) => void;
+    getCurrentUserActiveStream?: () => ApplicationStreamLike | null;
+    getViewerIds?: (stream: ApplicationStreamLike) => string[];
+}
+
+type DisplayTrackConstraints = MediaTrackConstraints & {
+    resizeMode?: ConstrainDOMString;
+};
+
+type MutableVideoTrackStreamLike = Pick<MediaStream, "getVideoTracks" | "removeTrack" | "addTrack">;
+
+type MutableRtpSendParameters = RTCRtpSendParameters & {
+    degradationPreference?: "balanced" | "maintain-framerate" | "maintain-resolution";
+};
+
+interface ScreenShareCaptureProfile {
+    frameRate: number;
+    height: number;
+    width: number;
+}
+
+interface SelfStreamViewerMonitorState {
+    hadViewer: boolean;
+    rejoinArmed: boolean;
+    streamIdentity?: string;
+    viewerCount: number;
+}
+
+interface RemoteSinkMonitorState {
+    hadPositiveSink: boolean;
+    rejoinArmed: boolean;
+}
+
+interface RemoteVideoSinkWantsLike {
+    any?: number;
+    pixelCounts?: Record<string, number>;
+    [key: string]: number | Record<string, number> | undefined;
+}
+
+interface RemoteVideoSinkWantsAction {
+    wants?: RemoteVideoSinkWantsLike;
+}
+
+interface DirectScreenShareSinkWantsPropertyPatchState {
+    localPropertyPatched: boolean;
+    remotePropertyPatched: boolean;
+}
+
+interface PendingTrackConstraintSyncRequest {
+    connection: MediaConnectionLike | null | undefined;
+    force: boolean;
+}
+
+type DisplayMediaStreamOptionsLike = DisplayMediaStreamOptions & {
+    video?: boolean | MediaTrackConstraints;
+};
+
+const selfStreamViewerMonitorState: SelfStreamViewerMonitorState = {
+    hadViewer: false,
+    rejoinArmed: false,
+    viewerCount: 0
+};
+
+const remoteSinkMonitorState: RemoteSinkMonitorState = {
+    hadPositiveSink: false,
+    rejoinArmed: false
+};
+
+function rememberManagedScreenShareTrack(track: MediaStreamTrack | null | undefined) {
+    if (track?.kind === "video" && (track.contentHint === "detail" || track.contentHint === "motion")) {
+        managedScreenShareTracks.add(track);
+    }
+}
+
+function isManagedScreenShareTrack(track: MediaStreamTrack | null | undefined) {
+    return Boolean(
+        track &&
+        track.kind === "video" &&
+        managedScreenShareTracks.has(track) &&
+        (track.contentHint === "detail" || track.contentHint === "motion")
+    );
+}
+
+function isDetailDisplayTrack(track: MediaStreamTrack | null | undefined) {
+    return Boolean(track && track.kind === "video" && track.contentHint === "detail" && detailDisplayTracks.has(track));
+}
+
+function getManagedScreenShareDegradationPreference(
+    track: MediaStreamTrack
+): NonNullable<MutableRtpSendParameters["degradationPreference"]> {
+    return isDetailDisplayTrack(track) ? "balanced" : "maintain-framerate";
+}
+
+function getManagedScreenShareContentHint(track: MediaStreamTrack | null | undefined) {
+    if (!track || track.kind !== "video") {
+        return "";
+    }
+
+    return track.contentHint === "detail" || track.contentHint === "motion" ? track.contentHint : "";
+}
+
+function rememberManagedScreenShareModeTrack(track: MediaStreamTrack | null | undefined) {
+    rememberManagedScreenShareTrack(track);
+
+    if (track?.kind === "video" && track.contentHint === "detail") {
+        detailDisplayTracks.add(track);
+    }
+}
+
+function noteSenderParameterSyncFailure(sender: RTCRtpSender, message: string, error: unknown) {
+    const nextCount = (senderParameterSyncFailureCounts.get(sender) ?? 0) + 1;
+    senderParameterSyncFailureCounts.set(sender, nextCount);
+
+    if (nextCount === 1) {
+        logger.error(message, error);
+    }
+}
+
+function getErrorName(error: unknown) {
+    if (typeof error !== "object" || error === null || !("name" in error)) {
+        return "";
+    }
+
+    return String((error as { name?: unknown }).name ?? "");
+}
+
+function getErrorMessage(error: unknown) {
+    if (typeof error !== "object" || error === null || !("message" in error)) {
+        return "";
+    }
+
+    return String((error as { message?: unknown }).message ?? "");
+}
+
+function shouldRetrySenderParameterSyncFailure(error: unknown) {
+    const name = getErrorName(error);
+    const message = getErrorMessage(error);
+
+    return (
+        name === "InvalidModificationError" ||
+        name === "InvalidStateError" ||
+        message.includes("getParameters") ||
+        message.includes("setParameters") ||
+        message.includes("transaction")
+    );
+}
+
+function waitSenderParameterSyncRetryDelay() {
+    return new Promise<void>(resolve => {
+        window.setTimeout(resolve, senderParameterSyncRetryDelayMs);
+    });
+}
+
+function wait(delayMs: number) {
+    return new Promise<void>(resolve => {
+        window.setTimeout(resolve, delayMs);
+    });
+}
+
+function getNumericConstraintValue(value: ConstrainULong | ConstrainDouble | undefined) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+        return value;
+    }
+
+    if (!value || typeof value !== "object") {
+        return void 0;
+    }
+
+    const candidates = [value.exact, value.ideal, value.max, value.min];
+    return candidates.find(candidate => typeof candidate === "number" && Number.isFinite(candidate));
+}
+
+function getRequestedTrackFrameRate(track: MediaStreamTrack) {
+    const constraints = track.getConstraints() as DisplayTrackConstraints;
+    const constrainedFrameRate = getNumericConstraintValue(constraints.frameRate);
+    if (constrainedFrameRate !== void 0) {
+        return constrainedFrameRate;
+    }
+
+    // `getSettings().frameRate` can reflect transient live capture output on
+    // Linux screenshare. Treat the explicit constraint as the requested target
+    // first so healthy FPS drift does not trigger another applyConstraints().
+    const settings = track.getSettings();
+    if (typeof settings.frameRate === "number" && Number.isFinite(settings.frameRate)) {
+        return settings.frameRate;
+    }
+
+    return void 0;
+}
+
+function getCurrentScreenShareCaptureProfile(
+    connection: MediaConnectionLike | null | undefined
+): ScreenShareCaptureProfile {
+    const selectedProfile = getSelectedScreenShareProfile();
+    const streamParameters = getScreenShareConnectionVideoStreamParameters(connection);
+    const maxResolution = streamParameters?.maxResolution;
+
+    const frameRate = Number(streamParameters?.maxFrameRate);
+    const width = Number(maxResolution?.width);
+    const height = Number(maxResolution?.height);
+    const pixelCount = Number(streamParameters?.maxPixelCount);
+
+    const hasValidFrameRate = Number.isFinite(frameRate) && frameRate > 0;
+    const hasValidWidth = Number.isFinite(width) && width > 0;
+    const hasValidHeight = Number.isFinite(height) && height > 0;
+    const hasValidPixelCount = Number.isFinite(pixelCount) && pixelCount > 0;
+    const matchesSelectedDimensions =
+        hasValidWidth &&
+        hasValidHeight &&
+        width === selectedProfile.width &&
+        height === selectedProfile.height &&
+        (!hasValidPixelCount || pixelCount === selectedProfile.pixelCount);
+
+    return {
+        frameRate: hasValidFrameRate && frameRate === selectedProfile.frameRate ? frameRate : selectedProfile.frameRate,
+        height: matchesSelectedDimensions ? height : selectedProfile.height,
+        width: matchesSelectedDimensions ? width : selectedProfile.width
+    };
+}
+
+function buildManagedScreenShareConstraints(
+    baseConstraints: MediaTrackConstraints,
+    profile: ScreenShareCaptureProfile
+): DisplayTrackConstraints {
+    const advanced = Array.isArray(baseConstraints.advanced) ? [...baseConstraints.advanced] : [];
+    advanced.push({ width: profile.width, height: profile.height });
+
+    return {
+        ...baseConstraints,
+        frameRate: { min: profile.frameRate, ideal: profile.frameRate, max: profile.frameRate },
+        width: { min: 640, ideal: profile.width, max: profile.width },
+        height: { min: 480, ideal: profile.height, max: profile.height },
+        advanced,
+        resizeMode: "none"
+    };
+}
+
+function buildManagedScreenShareRequestConstraints(
+    baseConstraints: MediaTrackConstraints,
+    profile: ScreenShareCaptureProfile
+): DisplayTrackConstraints {
+    const { advanced: _advanced, ...requestConstraints } = baseConstraints;
+
+    // Electron rejects `advanced` during getDisplayMedia() request validation.
+    // Keep request-time constraints conservative, then tighten them on the live track.
+    return {
+        ...requestConstraints,
+        frameRate: { ideal: profile.frameRate },
+        width: { ideal: profile.width },
+        height: { ideal: profile.height },
+        resizeMode: "none"
+    };
+}
+
+function buildManagedScreenShareTrackConstraints(
+    track: MediaStreamTrack,
+    connection: MediaConnectionLike | null | undefined
+): DisplayTrackConstraints {
+    const profile = getCurrentScreenShareCaptureProfile(connection);
+    return buildManagedScreenShareConstraints(track.getConstraints(), profile);
+}
+
+function mergeTrackConstraintSyncRequest(
+    previous: PendingTrackConstraintSyncRequest | undefined,
+    connection: MediaConnectionLike | null | undefined,
+    force: boolean
+): PendingTrackConstraintSyncRequest {
+    return {
+        connection: connection ?? previous?.connection,
+        force: force || previous?.force || false
+    };
+}
+
+function notePendingTrackConstraintSyncRequest(
+    track: MediaStreamTrack,
+    connection: MediaConnectionLike | null | undefined,
+    force: boolean
+) {
+    trackConstraintSyncPendingRequests.set(
+        track,
+        mergeTrackConstraintSyncRequest(trackConstraintSyncPendingRequests.get(track), connection, force)
+    );
+    trackConstraintSyncPending.set(track, true);
+}
+
+function isExpectedTrackConstraintSyncFailure(track: MediaStreamTrack, error: unknown) {
+    const name = getErrorName(error);
+    return track.readyState !== "live" || name === "AbortError" || name === "InvalidStateError";
+}
+
+async function syncManagedScreenShareTrackConstraintsOnce(
+    track: MediaStreamTrack,
+    connection: MediaConnectionLike | null | undefined,
+    force = false
+) {
+    if (track.kind !== "video" || !isManagedScreenShareTrack(track) || track.readyState !== "live") {
+        return;
+    }
+
+    const profile = getCurrentScreenShareCaptureProfile(connection);
+    const settings = track.getSettings();
+    const constraints = track.getConstraints() as DisplayTrackConstraints;
+
+    const currentWidth = settings.width ?? getNumericConstraintValue(constraints.width);
+    const currentHeight = settings.height ?? getNumericConstraintValue(constraints.height);
+    const currentFrameRate = getRequestedTrackFrameRate(track);
+    const desiredContentHint =
+        getManagedScreenShareContentHint(track) ||
+        (typeof currentSettings?.contentHint === "string" ? currentSettings.contentHint : "detail");
+
+    const hasTargetDimensions = currentWidth === profile.width && currentHeight === profile.height;
+    const hasTargetFrameRate = currentFrameRate !== void 0 && Math.round(currentFrameRate) === profile.frameRate;
+    const hasTargetResizeMode = constraints.resizeMode === "none";
+    const hasTargetContentHint = track.contentHint === desiredContentHint;
+
+    if (!force && hasTargetDimensions && hasTargetFrameRate && hasTargetResizeMode && hasTargetContentHint) {
+        return;
+    }
+
+    const now = Date.now();
+    const lastAttemptAt = trackConstraintSyncAttemptAt.get(track) ?? 0;
+    if (!force && now - lastAttemptAt < screenShareTrackConstraintSyncCooldownMs) {
+        return;
+    }
+
+    trackConstraintSyncAttemptAt.set(track, now);
+
+    if (track.contentHint !== desiredContentHint) {
+        track.contentHint = desiredContentHint;
+    }
+
+    try {
+        await track.applyConstraints(buildManagedScreenShareTrackConstraints(track, connection));
+    } catch (error) {
+        if (isExpectedTrackConstraintSyncFailure(track, error)) {
+            return;
+        }
+
+        logger.error("Failed to sync screenshare track constraints", error);
+    }
+}
+
+async function syncManagedScreenShareTrackConstraints(
+    track: MediaStreamTrack,
+    connection: MediaConnectionLike | null | undefined,
+    force = false
+) {
+    const currentTask = trackConstraintSyncTasks.get(track);
+    if (currentTask) {
+        notePendingTrackConstraintSyncRequest(track, connection, force);
+        return currentTask;
+    }
+
+    // Coalesce overlapping sync requests per track so applyConstraints() never races itself.
+    const task = (async () => {
+        let request: PendingTrackConstraintSyncRequest | undefined = { connection, force };
+
+        do {
+            trackConstraintSyncPending.set(track, false);
+            trackConstraintSyncPendingRequests.delete(track);
+
+            await syncManagedScreenShareTrackConstraintsOnce(track, request.connection, request.force);
+
+            request = trackConstraintSyncPending.get(track) ? trackConstraintSyncPendingRequests.get(track) : void 0;
+        } while (request);
+    })().finally(() => {
+        trackConstraintSyncPending.delete(track);
+        trackConstraintSyncPendingRequests.delete(track);
+        trackConstraintSyncTasks.delete(track);
+    });
+
+    trackConstraintSyncTasks.set(track, task);
+    return task;
+}
+
+async function syncManagedScreenShareSenderParametersOnce(sender: RTCRtpSender, allowRetry = true) {
+    const { track } = sender;
+    if (!track || !isManagedScreenShareTrack(track) || track.readyState !== "live") {
+        senderParameterSyncFailureCounts.delete(sender);
+        return;
+    }
+
+    let parameters: MutableRtpSendParameters;
+
+    try {
+        parameters = sender.getParameters() as MutableRtpSendParameters;
+    } catch (error) {
+        noteSenderParameterSyncFailure(sender, "Failed to read screenshare sender RTP parameters", error);
+        return;
+    }
+
+    const profile = getSelectedScreenShareProfile();
+    const bitrateProfile = getSelectedScreenShareBitrateProfile(profile);
+    const isDetailTrack = isDetailDisplayTrack(track);
+    const degradationPreference = getManagedScreenShareDegradationPreference(track);
+    const connectionStreamParameters = getScreenShareConnectionVideoStreamParameters(findLocalStreamConnection(track));
+    const desiredMaxBitrate = Number(connectionStreamParameters?.maxBitrate ?? bitrateProfile.max);
+    const encodings = parameters.encodings?.length ? [...parameters.encodings] : [{}];
+    let changed = !parameters.encodings?.length;
+
+    for (const encoding of encodings) {
+        if (encoding.active !== true) {
+            encoding.active = true;
+            changed = true;
+        }
+
+        if (encoding.maxBitrate !== desiredMaxBitrate) {
+            encoding.maxBitrate = desiredMaxBitrate;
+            changed = true;
+        }
+
+        if (encoding.maxFramerate !== profile.frameRate) {
+            encoding.maxFramerate = profile.frameRate;
+            changed = true;
+        }
+    }
+
+    if (!parameters.degradationPreference) {
+        parameters.degradationPreference = degradationPreference;
+        changed = true;
+    }
+
+    if (!changed) {
+        senderParameterSyncFailureCounts.delete(sender);
+        return;
+    }
+
+    parameters.encodings = encodings;
+
+    try {
+        await sender.setParameters(parameters);
+        senderParameterSyncFailureCounts.delete(sender);
+    } catch (error) {
+        // Discord can mutate the same sender during recovery/reconfigure.
+        // Retry once with a fresh getParameters() snapshot if the transaction went stale.
+        if (allowRetry && shouldRetrySenderParameterSyncFailure(error)) {
+            await waitSenderParameterSyncRetryDelay();
+            await syncManagedScreenShareSenderParametersOnce(sender, false);
+            return;
+        }
+
+        noteSenderParameterSyncFailure(sender, "Failed to sync screenshare sender RTP parameters", error);
+    }
+}
+
+async function syncManagedScreenShareSenderParameters(sender: RTCRtpSender) {
+    const currentTask = senderParameterSyncTasks.get(sender);
+    if (currentTask) {
+        senderParameterSyncPending.set(sender, true);
+        return currentTask;
+    }
+
+    const task = (async () => {
+        do {
+            senderParameterSyncPending.set(sender, false);
+            await syncManagedScreenShareSenderParametersOnce(sender);
+        } while (senderParameterSyncPending.get(sender));
+    })().finally(() => {
+        senderParameterSyncPending.delete(sender);
+        senderParameterSyncTasks.delete(sender);
+    });
+
+    senderParameterSyncTasks.set(sender, task);
+    return task;
+}
+
+async function syncActiveScreenShareSenderParameters() {
+    for (const pc of trackedScreenSharePeerConnections) {
+        if (pc.connectionState === "closed" || pc.iceConnectionState === "closed") {
+            continue;
+        }
+
+        for (const sender of pc.getSenders()) {
+            const { track } = sender;
+            if (!track || !isManagedScreenShareTrack(track) || track.readyState !== "live") {
+                continue;
+            }
+
+            await syncManagedScreenShareSenderParameters(sender);
+        }
+    }
+}
+
+function getMediaEngineConnections() {
+    try {
+        return [...MediaEngineStore.getMediaEngine().connections] as MediaConnectionLike[];
+    } catch (error) {
+        logger.error("Failed to enumerate media engine connections", error);
+        return [];
+    }
+}
+
+function getRelatedMediaConnectionCandidates(connection: MediaConnectionLike) {
+    const candidates = [connection];
+    const { videoQualityManager } = connection as Record<string, unknown>;
+
+    if (videoQualityManager && typeof videoQualityManager === "object") {
+        const { connection: nestedConnection } = videoQualityManager as Record<string, unknown>;
+        if (nestedConnection && typeof nestedConnection === "object" && nestedConnection !== connection) {
+            candidates.push(nestedConnection as MediaConnectionLike);
+        }
+    }
+
+    return candidates;
+}
+
+function getMediaEngineConnectionCandidates() {
+    const candidates = [] as MediaConnectionLike[];
+    const seenConnections = new Set<MediaConnectionLike>();
+
+    for (const connection of getMediaEngineConnections()) {
+        for (const candidate of getRelatedMediaConnectionCandidates(connection)) {
+            if (seenConnections.has(candidate)) {
+                continue;
+            }
+
+            seenConnections.add(candidate);
+            candidates.push(candidate);
+        }
+    }
+
+    return candidates;
+}
+
+function getConnectionVideoTracks(connection: MediaConnectionLike) {
+    const tracks = new Map<string, MediaStreamTrack>();
+
+    const add_tracks = (candidate_tracks: MediaStreamTrack[] | undefined) => {
+        for (const track of candidate_tracks ?? []) {
+            if (track.kind === "video") {
+                tracks.set(track.id, track);
+            }
+        }
+    };
+
+    add_tracks(connection.input?.stream?.getVideoTracks?.());
+    add_tracks(connection.input?.desktop?.stream?.getVideoTracks?.());
+
+    return [...tracks.values()];
+}
+
+function cloneRemoteVideoSinkWants(wants: RemoteVideoSinkWantsLike) {
+    const nextWants = {} as RemoteVideoSinkWantsLike;
+
+    for (const [key, value] of Object.entries(wants)) {
+        if (key === "pixelCounts") {
+            if (value && typeof value === "object") {
+                nextWants.pixelCounts = { ...(value as Record<string, number>) };
+            }
+
+            continue;
+        }
+
+        if (typeof value === "number" && Number.isFinite(value)) {
+            nextWants[key] = value;
+        }
+    }
+
+    return nextWants;
+}
+
+function getConnectionPrimaryScreenShareSsrc(connection: MediaConnectionLike) {
+    const streamParameters = connection.videoStreamParameters ?? [];
+    const primaryParameter =
+        streamParameters.find(
+            parameter => Number(parameter?.ssrc ?? 0) > 0 && Number(parameter?.quality ?? 0) >= 100
+        ) ??
+        streamParameters.find(parameter => Number(parameter?.ssrc ?? 0) > 0) ??
+        null;
+    const primarySsrc = Number(primaryParameter?.ssrc ?? 0);
+
+    return Number.isFinite(primarySsrc) && primarySsrc > 0 ? String(primarySsrc) : "";
+}
+
+function getConnectionScreenSharePixelCount(connection: MediaConnectionLike) {
+    const primaryParameter =
+        connection.videoStreamParameters?.find(parameter => Number(parameter?.maxPixelCount ?? 0) > 0) ?? null;
+    const parameterPixelCount = Number(primaryParameter?.maxPixelCount ?? 0);
+    if (Number.isFinite(parameterPixelCount) && parameterPixelCount > 0) {
+        return parameterPixelCount;
+    }
+
+    const profile = getCurrentScreenShareCaptureProfile(connection);
+    const profilePixelCount = profile.width * profile.height;
+    return profilePixelCount > 0 ? profilePixelCount : 0;
+}
+
+function hasDirectScreenSharePatchTarget(connection: MediaConnectionLike) {
+    if (getConnectionPrimaryScreenShareSsrc(connection)) {
+        return true;
+    }
+
+    return getConnectionVideoTracks(connection).some(track => isManagedScreenShareTrack(track));
+}
+
+function promoteGenericDirectScreenShareSinkWants(connection: MediaConnectionLike, wants: RemoteVideoSinkWantsLike) {
+    const genericWant = Number(wants.any ?? 0);
+    if (!(genericWant > 0)) {
+        return null;
+    }
+
+    const hasExplicitPositiveSink = Object.entries(wants).some(([key, value]) => {
+        return (
+            key !== "any" && key !== "pixelCounts" && typeof value === "number" && Number.isFinite(value) && value > 0
+        );
+    });
+    if (hasExplicitPositiveSink) {
+        return null;
+    }
+
+    const primarySsrc = getConnectionPrimaryScreenShareSsrc(connection);
+    if (!primarySsrc) {
+        return null;
+    }
+
+    const nextWants = cloneRemoteVideoSinkWants(wants);
+    nextWants[primarySsrc] = genericWant;
+
+    const pixelCount = getConnectionScreenSharePixelCount(connection);
+    if (pixelCount > 0) {
+        nextWants.pixelCounts = {
+            ...(nextWants.pixelCounts ?? {}),
+            [primarySsrc]: pixelCount
+        };
+    }
+
+    return nextWants;
+}
+
+function installDirectScreenShareSinkWantsPropertyPatch(
+    connection: MediaConnectionLike,
+    propertyName: "localVideoSinkWants" | "remoteVideoSinkWants"
+) {
+    const connectionRecord = connection as Record<string, unknown>;
+    const existingDescriptor = Object.getOwnPropertyDescriptor(connectionRecord, propertyName);
+
+    if (existingDescriptor?.configurable === false) {
+        return false;
+    }
+
+    if (existingDescriptor?.get || existingDescriptor?.set) {
+        return false;
+    }
+
+    let storedValue =
+        existingDescriptor && "value" in existingDescriptor ? existingDescriptor.value : connectionRecord[propertyName];
+
+    const maybePromote = (candidate: unknown) => {
+        if (!candidate || typeof candidate !== "object") {
+            return candidate;
+        }
+
+        return promoteGenericDirectScreenShareSinkWants(connection, candidate as RemoteVideoSinkWantsLike) ?? candidate;
+    };
+
+    Object.defineProperty(connectionRecord, propertyName, {
+        configurable: true,
+        enumerable: existingDescriptor?.enumerable ?? true,
+        get() {
+            const promotedValue = maybePromote(storedValue);
+            if (promotedValue !== storedValue) {
+                storedValue = promotedValue;
+            }
+
+            return storedValue;
+        },
+        set(nextValue: unknown) {
+            storedValue = maybePromote(nextValue);
+        }
+    });
+
+    storedValue = maybePromote(storedValue);
+    return true;
+}
+
+function installDirectScreenShareSinkWantsPropertyPatches(connection: MediaConnectionLike) {
+    const existingState = directScreenShareSinkWantsPropertyPatchStates.get(connection);
+    if (existingState) {
+        return existingState;
+    }
+
+    const nextState: DirectScreenShareSinkWantsPropertyPatchState = {
+        localPropertyPatched: installDirectScreenShareSinkWantsPropertyPatch(connection, "localVideoSinkWants"),
+        remotePropertyPatched: installDirectScreenShareSinkWantsPropertyPatch(connection, "remoteVideoSinkWants")
+    };
+
+    directScreenShareSinkWantsPropertyPatchStates.set(connection, nextState);
+    return nextState;
+}
+
+function maybeForceDirectLocalStreamParameterActivation(connection: MediaConnectionLike, args: unknown[]) {
+    if (!args.length) {
+        return args;
+    }
+
+    const firstArg = args[0];
+    if (!firstArg || typeof firstArg !== "object") {
+        return args;
+    }
+
+    const options = firstArg as Record<string, unknown>;
+    if (!Array.isArray(options.streamParameters) || !options.streamParameters.length) {
+        return args;
+    }
+    const streamParameters = options.streamParameters as unknown[];
+
+    const primarySsrc = getConnectionPrimaryScreenShareSsrc(connection);
+    if (!primarySsrc) {
+        return args;
+    }
+
+    let changed = false;
+    const nextStreamParameters = streamParameters.map(parameter => {
+        if (!parameter || typeof parameter !== "object") {
+            return parameter;
+        }
+
+        const record = parameter as Record<string, unknown>;
+        const matchesPrimary = String(record.ssrc ?? "") === primarySsrc;
+        const shouldActivate = matchesPrimary || streamParameters.length === 1;
+        if (!shouldActivate || record.active === true) {
+            return parameter;
+        }
+
+        changed = true;
+        return {
+            ...record,
+            active: true
+        };
+    });
+
+    if (!changed) {
+        return args;
+    }
+
+    const nextArgs = [...args];
+    nextArgs[0] = {
+        ...options,
+        streamParameters: nextStreamParameters
+    };
+
+    return nextArgs;
+}
+
+function installDirectLocalScreenShareSinkWantsPatch(connection: MediaConnectionLike | null | undefined) {
+    if (
+        !connection ||
+        typeof connection.updateVideoQuality !== "function" ||
+        !hasDirectScreenSharePatchTarget(connection)
+    ) {
+        return;
+    }
+
+    const propertyPatchState = installDirectScreenShareSinkWantsPropertyPatches(connection);
+    const currentUpdateVideoQuality = connection.updateVideoQuality;
+    const installedWrapper = directLocalScreenShareSinkWantsPatchedUpdateVideoQuality.get(connection);
+    if (installedWrapper && currentUpdateVideoQuality === installedWrapper) {
+        return;
+    }
+
+    const originalUpdateVideoQuality = currentUpdateVideoQuality;
+    const wrappedUpdateVideoQuality = (...args: unknown[]) => {
+        if (!propertyPatchState.localPropertyPatched) {
+            const promotedLocalWants = connection.localVideoSinkWants
+                ? promoteGenericDirectScreenShareSinkWants(connection, connection.localVideoSinkWants)
+                : null;
+            if (promotedLocalWants) {
+                connection.localVideoSinkWants = promotedLocalWants;
+            }
+        }
+
+        if (!propertyPatchState.remotePropertyPatched) {
+            const promotedRemoteWants = connection.remoteVideoSinkWants
+                ? promoteGenericDirectScreenShareSinkWants(connection, connection.remoteVideoSinkWants)
+                : null;
+            if (promotedRemoteWants) {
+                connection.remoteVideoSinkWants = promotedRemoteWants;
+            }
+        }
+
+        return originalUpdateVideoQuality.apply(
+            connection,
+            maybeForceDirectLocalStreamParameterActivation(connection, args)
+        );
+    };
+    connection.updateVideoQuality = wrappedUpdateVideoQuality;
+
+    directLocalScreenShareSinkWantsPatchedUpdateVideoQuality.set(connection, wrappedUpdateVideoQuality);
+}
+
+function rememberLocalConnectionTrack(
+    track: MediaStreamTrack | null | undefined,
+    connection: MediaConnectionLike | null | undefined
+) {
+    if (!track || track.kind !== "video" || !connection) {
+        return;
+    }
+
+    trackLocalConnectionHints.set(track, connection);
+}
+
+async function syncActiveScreenShareTracks(force = false) {
+    const currentUserId = UserStore.getCurrentUser()?.id;
+    if (!currentUserId) {
+        return;
+    }
+
+    const connections = getMediaEngineConnectionCandidates().filter(
+        connection => connection.streamUserId === currentUserId
+    );
+
+    for (const connection of connections) {
+        installDirectLocalScreenShareSinkWantsPatch(connection);
+        syncSelectedScreenShareVideoStreamParameters(getScreenShareConnectionVideoStreamParameters(connection));
+
+        for (const track of getConnectionVideoTracks(connection)) {
+            rememberManagedScreenShareModeTrack(track);
+
+            if (!isManagedScreenShareTrack(track)) {
+                continue;
+            }
+
+            rememberLocalConnectionTrack(track, connection);
+            await syncManagedScreenShareTrackConstraints(track, connection, force);
+        }
+    }
+
+    await syncActiveScreenShareSenderParameters();
+}
+
+function scheduleActiveScreenShareTrackSync(force = false) {
+    const currentSequence = ++activeDetailTrackSyncSequence;
+    let allowForcedWave = force;
+
+    for (const delayMs of screenShareProfileChangeSyncDelaysMs) {
+        const waveForce = allowForcedWave;
+        allowForcedWave = false;
+
+        window.setTimeout(() => {
+            if (currentSequence !== activeDetailTrackSyncSequence) {
+                return;
+            }
+
+            // A full forced applyConstraints() wave is expensive on Linux screenshare.
+            // Keep one immediate hard reapply, then let delayed waves only verify/correct drift.
+            void syncActiveScreenShareTracks(waveForce);
+        }, delayMs);
+    }
+}
+
+function getSenderRecoveryState(sender: RTCRtpSender) {
+    const existingState = senderRecoveryStates.get(sender);
+    if (existingState) {
+        return existingState;
+    }
+
+    const nextState: SenderRecoveryState = {
+        inRecovery: false
+    };
+
+    senderRecoveryStates.set(sender, nextState);
+    return nextState;
+}
+
+function findLocalStreamConnection(track: MediaStreamTrack) {
+    try {
+        const currentUserId = UserStore.getCurrentUser()?.id;
+        const connections = getMediaEngineConnectionCandidates();
+        const hintedConnection = trackLocalConnectionHints.get(track);
+
+        for (const connection of connections) {
+            if (getConnectionVideoTracks(connection).some(candidate => candidate.id === track.id)) {
+                rememberLocalConnectionTrack(track, connection);
+                installDirectLocalScreenShareSinkWantsPatch(connection);
+                return connection;
+            }
+        }
+
+        if (hintedConnection && connections.includes(hintedConnection)) {
+            installDirectLocalScreenShareSinkWantsPatch(hintedConnection);
+            return hintedConnection;
+        }
+
+        const fallbackConnection = connections.find(connection => connection.streamUserId === currentUserId) ?? null;
+        installDirectLocalScreenShareSinkWantsPatch(fallbackConnection);
+        return fallbackConnection;
+    } catch (error) {
+        logger.error("Failed to resolve local media engine connection", error);
+        return null;
+    }
+}
+
+async function tryKickConnectionNegotiation(connection: MediaConnectionLike | null) {
+    if (!connection || typeof connection.handleNegotiationNeeded !== "function") {
+        return;
+    }
+
+    try {
+        connection.negotiationNeeded = true;
+        await Promise.resolve(connection.handleNegotiationNeeded());
+    } catch (error) {
+        logger.error("Local connection negotiation hook failed", error);
+    }
+}
+
+function clearViewerRejoinRecoveryTimer() {
+    if (viewerRejoinRecoveryTimer !== void 0) {
+        clearTimeout(viewerRejoinRecoveryTimer);
+        viewerRejoinRecoveryTimer = void 0;
+    }
+}
+
+function getApplicationStreamIdentity(stream: ApplicationStreamLike | null | undefined) {
+    if (!stream?.ownerId || !stream.channelId || !stream.streamType) {
+        return "";
+    }
+
+    return `${stream.streamType}:${stream.guildId ?? "noguild"}:${stream.channelId}:${stream.ownerId}`;
+}
+
+function resetRemoteSinkMonitorState() {
+    remoteSinkMonitorState.hadPositiveSink = false;
+    remoteSinkMonitorState.rejoinArmed = false;
+}
+
+function resetSelfStreamViewerState() {
+    clearViewerRejoinRecoveryTimer();
+    selfStreamViewerMonitorState.hadViewer = false;
+    selfStreamViewerMonitorState.rejoinArmed = false;
+    selfStreamViewerMonitorState.streamIdentity = void 0;
+    selfStreamViewerMonitorState.viewerCount = 0;
+    resetRemoteSinkMonitorState();
+}
+
+function hasActiveScreenShareSender() {
+    for (const pc of trackedScreenSharePeerConnections) {
+        if (pc.connectionState === "closed" || pc.iceConnectionState === "closed") {
+            continue;
+        }
+
+        for (const sender of pc.getSenders()) {
+            const { track } = sender;
+            if (track && isManagedScreenShareTrack(track) && track.readyState === "live") {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+function hasPositiveRemoteSinkDemand(wants: RemoteVideoSinkWantsLike | undefined) {
+    if (!wants) {
+        return false;
+    }
+
+    return Object.entries(wants).some(([key, value]) => {
+        return key !== "pixelCounts" && typeof value === "number" && Number.isFinite(value) && value > 0;
+    });
+}
+
+function isMutableVideoTrackStream(stream: unknown): stream is MutableVideoTrackStreamLike {
+    return Boolean(
+        stream &&
+        typeof stream === "object" &&
+        "getVideoTracks" in stream &&
+        typeof stream.getVideoTracks === "function" &&
+        "removeTrack" in stream &&
+        typeof stream.removeTrack === "function" &&
+        "addTrack" in stream &&
+        typeof stream.addTrack === "function"
+    );
+}
+
+function replaceVideoTrackInStream(
+    stream: MutableVideoTrackStreamLike,
+    originalTrack: MediaStreamTrack,
+    nextTrack: MediaStreamTrack
+) {
+    const videoTracks = stream.getVideoTracks();
+    const hasRelevantTrack = videoTracks.some(track => track.id === originalTrack.id || track.id === nextTrack.id);
+    if (!hasRelevantTrack) {
+        return false;
+    }
+
+    for (const videoTrack of videoTracks) {
+        if (videoTrack.id !== nextTrack.id) {
+            stream.removeTrack(videoTrack);
+        }
+    }
+
+    if (!stream.getVideoTracks().some(track => track.id === nextTrack.id)) {
+        stream.addTrack(nextTrack);
+    }
+
+    return true;
+}
+
+function retireReplacedScreenShareTrack(originalTrack: MediaStreamTrack, nextTrack: MediaStreamTrack) {
+    if (originalTrack.id === nextTrack.id) {
+        return;
+    }
+
+    managedScreenShareTracks.delete(originalTrack);
+    detailDisplayTracks.delete(originalTrack);
+    trackLocalConnectionHints.delete(originalTrack);
+    trackConstraintSyncAttemptAt.delete(originalTrack);
+
+    if (originalTrack.readyState !== "live") {
+        return;
+    }
+
+    try {
+        originalTrack.stop();
+    } catch (error) {
+        logger.error("Failed to stop replaced detail screenshare track", error);
+    }
+}
+
+function trySyncLocalDesktopTrack(
+    connection: MediaConnectionLike | null,
+    originalTrack: MediaStreamTrack,
+    nextTrack: MediaStreamTrack
+) {
+    const input = connection?.input;
+    const streams = [input?.desktop?.stream, input?.stream].filter(isMutableVideoTrackStream);
+    if (!streams.length) {
+        return false;
+    }
+
+    let synchronizedStream = false;
+    const seenStreams = new Set<MutableVideoTrackStreamLike>();
+
+    for (const stream of streams) {
+        if (seenStreams.has(stream)) {
+            continue;
+        }
+
+        seenStreams.add(stream);
+        synchronizedStream = replaceVideoTrackInStream(stream, originalTrack, nextTrack) || synchronizedStream;
+    }
+
+    if (!synchronizedStream) {
+        return false;
+    }
+
+    input?.mergeStreams?.();
+    rememberLocalConnectionTrack(nextTrack, connection);
+    return true;
+}
+
+async function replaceTrackDuringRecovery(sender: RTCRtpSender, track: MediaStreamTrack | null) {
+    recoveryManagedReplaceTrackSenders.add(sender);
+
+    try {
+        await sender.replaceTrack(track);
+    } finally {
+        recoveryManagedReplaceTrackSenders.delete(sender);
+    }
+}
+
+async function syncRecoveredScreenShareSender(
+    sender: RTCRtpSender,
+    track: MediaStreamTrack,
+    connection: MediaConnectionLike | null | undefined
+) {
+    syncSelectedScreenShareVideoStreamParameters(getScreenShareConnectionVideoStreamParameters(connection));
+    await syncManagedScreenShareTrackConstraints(track, connection, true);
+    await syncManagedScreenShareSenderParameters(sender);
+}
+
+function attachManagedScreenShareSender(pc: RTCPeerConnection, sender: RTCRtpSender, track: MediaStreamTrack | null) {
+    senderPeerConnections.set(sender, pc);
+
+    if (!isManagedScreenShareTrack(track)) {
+        return;
+    }
+
+    trackPeerConnection(pc);
+    void syncManagedScreenShareSenderParameters(sender);
+}
+
+function untrackPeerConnection(pc: RTCPeerConnection) {
+    trackedScreenSharePeerConnections.delete(pc);
+}
+
+function trackPeerConnection(pc: RTCPeerConnection) {
+    trackedScreenSharePeerConnections.add(pc);
+
+    if (trackedPeerConnections.has(pc)) {
+        return;
+    }
+
+    trackedPeerConnections.add(pc);
+
+    const stopIfClosed = () => {
+        if (pc.connectionState === "closed" || pc.iceConnectionState === "closed") {
+            untrackPeerConnection(pc);
+        }
+    };
+
+    pc.addEventListener("connectionstatechange", stopIfClosed);
+    pc.addEventListener("iceconnectionstatechange", stopIfClosed);
+}
+
+function isVideoOutboundRtpStreamStats(report: RTCStats): report is RTCOutboundRtpStreamStats {
+    if (report.type !== "outbound-rtp") {
+        return false;
+    }
+
+    const outbound = report as RTCOutboundRtpStreamStats & { mediaType?: string };
+    return outbound.kind === "video" || outbound.mediaType === "video";
+}
+
+function selectPrimaryVideoOutboundReport(outboundReports: RTCOutboundRtpStreamStats[]) {
+    return outboundReports.reduce((bestReport, currentReport) => {
+        const bestScore = (bestReport.bytesSent ?? 0) + (bestReport.framesEncoded ?? 0) * 1024;
+        const currentScore = (currentReport.bytesSent ?? 0) + (currentReport.framesEncoded ?? 0) * 1024;
+
+        return currentScore > bestScore ? currentReport : bestReport;
+    });
+}
+
+function makeVideoSenderSnapshot(outbound: RTCOutboundRtpStreamStats): VideoSenderSnapshot {
+    return {
+        bytesSent: outbound.bytesSent ?? 0,
+        framesEncoded: outbound.framesEncoded ?? 0,
+        frameWidth: outbound.frameWidth,
+        frameHeight: outbound.frameHeight,
+        sampledAt: performance.now()
+    };
+}
+
+function hasRenderableDimensions(snapshot: VideoSenderSnapshot) {
+    return (snapshot.frameWidth ?? 0) > 0 && (snapshot.frameHeight ?? 0) > 0;
+}
+
+function hasSenderSnapshotProgress(
+    previousSnapshot: VideoSenderSnapshot | null,
+    currentSnapshot: VideoSenderSnapshot | null
+) {
+    if (!previousSnapshot || !currentSnapshot) {
+        return false;
+    }
+
+    return (
+        currentSnapshot.framesEncoded > previousSnapshot.framesEncoded ||
+        currentSnapshot.bytesSent > previousSnapshot.bytesSent
+    );
+}
+
+async function getPrimaryVideoSenderSnapshot(sender: RTCRtpSender) {
+    const senderStats = await sender.getStats();
+    const outboundReports = [...senderStats.values()].filter(isVideoOutboundRtpStreamStats);
+    if (!outboundReports.length) {
+        return null;
+    }
+
+    return makeVideoSenderSnapshot(selectPrimaryVideoOutboundReport(outboundReports));
+}
+
+async function hasRecentSenderOutputHealth(sender: RTCRtpSender) {
+    const firstSnapshot = await getPrimaryVideoSenderSnapshot(sender);
+    if (!firstSnapshot) {
+        return false;
+    }
+
+    await wait(audienceRecoveryHealthProbeDelayMs);
+
+    const secondSnapshot = await getPrimaryVideoSenderSnapshot(sender);
+    const latestSnapshot = secondSnapshot ?? firstSnapshot;
+    if (!hasRenderableDimensions(latestSnapshot) || latestSnapshot.framesEncoded === 0) {
+        return false;
+    }
+
+    return latestSnapshot.bytesSent > 0 || hasSenderSnapshotProgress(firstSnapshot, secondSnapshot);
+}
+
+async function shouldRecoverSenderForAudienceEvent(sender: RTCRtpSender, _reason: string) {
+    const { track } = sender;
+    if (!track || !isManagedScreenShareTrack(track) || track.readyState !== "live") {
+        return false;
+    }
+
+    /*
+     * Viewer attach/rejoin already primes the safe constraint/parameter resync
+     * path. Only escalate to replaceTrack-based recovery when the sender still
+     * looks stalled afterwards; otherwise healthy detail-share sessions get
+     * churned precisely when a viewer joins.
+     */
+    return !(await hasRecentSenderOutputHealth(sender));
+}
+
+async function tryRecoverStalledVideoSender(sender: RTCRtpSender, reason: string) {
+    if (!senderPeerConnections.get(sender)) {
+        return false;
+    }
+
+    const state = getSenderRecoveryState(sender);
+    if (state.inRecovery) {
+        return false;
+    }
+
+    const { track } = sender;
+    if (!track || !isManagedScreenShareTrack(track)) {
+        return false;
+    }
+
+    const now = Date.now();
+    if (state.lastRecoveryAt !== void 0 && now - state.lastRecoveryAt < screenShareRecoveryCooldownMs) {
+        return false;
+    }
+
+    state.inRecovery = true;
+    state.lastRecoveryAt = now;
+
+    try {
+        const localConnection = findLocalStreamConnection(track);
+
+        try {
+            const clonedTrack = track.clone();
+            clonedTrack.contentHint = track.contentHint;
+            clonedTrack.enabled = track.enabled;
+            rememberManagedScreenShareModeTrack(clonedTrack);
+
+            await replaceTrackDuringRecovery(sender, clonedTrack);
+            await syncRecoveredScreenShareSender(sender, clonedTrack, localConnection);
+
+            const synchronizedDesktopTrack = trySyncLocalDesktopTrack(localConnection, track, clonedTrack);
+            if (!synchronizedDesktopTrack) {
+                await tryKickConnectionNegotiation(localConnection);
+            }
+
+            scheduleActiveScreenShareTrackSync();
+
+            if (synchronizedDesktopTrack) {
+                retireReplacedScreenShareTrack(track, clonedTrack);
+            }
+        } catch (cloneReplaceError) {
+            logger.error("Cloned-track recovery step failed, trying null-track rebound fallback", cloneReplaceError);
+
+            await replaceTrackDuringRecovery(sender, null);
+            await replaceTrackDuringRecovery(sender, track);
+            await syncRecoveredScreenShareSender(sender, track, localConnection);
+
+            await tryKickConnectionNegotiation(localConnection);
+            scheduleActiveScreenShareTrackSync();
+        }
+
+        return true;
+    } catch (error) {
+        logger.error(`Failed screenshare sender recovery (${reason})`, error);
+        return false;
+    } finally {
+        state.inRecovery = false;
+    }
+}
+
+async function recoverActiveScreenShareSenders(reason: string) {
+    const recoveries = [] as Array<Promise<boolean>>;
+
+    for (const pc of trackedScreenSharePeerConnections) {
+        if (pc.connectionState === "closed" || pc.iceConnectionState === "closed") {
+            trackedScreenSharePeerConnections.delete(pc);
+            continue;
+        }
+
+        for (const sender of pc.getSenders()) {
+            const { track } = sender;
+            if (!track || !isManagedScreenShareTrack(track) || track.readyState !== "live") {
+                continue;
+            }
+
+            if (!(await shouldRecoverSenderForAudienceEvent(sender, reason))) {
+                continue;
+            }
+
+            recoveries.push(tryRecoverStalledVideoSender(sender, reason));
+        }
+    }
+
+    if (!recoveries.length) {
+        return false;
+    }
+
+    const results = await Promise.all(recoveries);
+    return results.some(Boolean);
+}
+
+function primeActiveScreenShareProfileSync() {
+    scheduleCurrentUserScreenShareVideoStreamParameterSync();
+    scheduleActiveScreenShareTrackSync(true);
+}
+
+function scheduleViewerAudienceRecovery(reason: "viewer-attach" | "viewer-rejoin", streamIdentity: string) {
+    clearViewerRejoinRecoveryTimer();
+
+    const currentSequence = ++viewerRejoinRecoverySequence;
+
+    primeActiveScreenShareProfileSync();
+
+    viewerRejoinRecoveryTimer = window.setTimeout(
+        () => {
+            viewerRejoinRecoveryTimer = void 0;
+
+            if (
+                currentSequence !== viewerRejoinRecoverySequence ||
+                selfStreamViewerMonitorState.streamIdentity !== streamIdentity ||
+                selfStreamViewerMonitorState.viewerCount === 0
+            ) {
+                return;
+            }
+
+            void recoverActiveScreenShareSenders(reason);
+        },
+        reason === "viewer-attach" ? viewerAttachRecoveryDelayMs : viewerRejoinRecoveryDelayMs
+    );
+}
+
+function scheduleRemoteSinkRecovery(reason: "viewer-attach" | "viewer-rejoin") {
+    clearViewerRejoinRecoveryTimer();
+
+    const currentSequence = ++viewerRejoinRecoverySequence;
+
+    primeActiveScreenShareProfileSync();
+
+    viewerRejoinRecoveryTimer = window.setTimeout(
+        () => {
+            viewerRejoinRecoveryTimer = void 0;
+
+            if (currentSequence !== viewerRejoinRecoverySequence || !remoteSinkMonitorState.hadPositiveSink) {
+                return;
+            }
+
+            void recoverActiveScreenShareSenders(reason);
+        },
+        reason === "viewer-attach" ? viewerAttachRecoveryDelayMs : viewerRejoinRecoveryDelayMs
+    );
+}
+
+function handleRemoteVideoSinkWants(action: RemoteVideoSinkWantsAction) {
+    try {
+        if (!hasActiveScreenShareSender()) {
+            resetRemoteSinkMonitorState();
+            return;
+        }
+
+        const { hadPositiveSink } = remoteSinkMonitorState;
+        const hasPositiveSinkDemand = hasPositiveRemoteSinkDemand(action.wants);
+
+        if (!hasPositiveSinkDemand) {
+            if (remoteSinkMonitorState.hadPositiveSink) {
+                remoteSinkMonitorState.hadPositiveSink = false;
+                remoteSinkMonitorState.rejoinArmed = true;
+            }
+
+            return;
+        }
+
+        remoteSinkMonitorState.hadPositiveSink = true;
+
+        if (remoteSinkMonitorState.rejoinArmed) {
+            remoteSinkMonitorState.rejoinArmed = false;
+            selfStreamViewerMonitorState.rejoinArmed = false;
+            scheduleRemoteSinkRecovery("viewer-rejoin");
+            return;
+        }
+
+        if (!hadPositiveSink) {
+            scheduleRemoteSinkRecovery("viewer-attach");
+        }
+    } catch (error) {
+        logger.error("Failed to evaluate remote video sink wants", error);
+    }
+}
+
+function handleSelfStreamViewerStateChange(streamingStore: ApplicationStreamingStoreLike) {
+    try {
+        const currentUserId = UserStore.getCurrentUser()?.id;
+        const stream = streamingStore.getCurrentUserActiveStream?.();
+        const hasTrackedScreenShareSender = hasActiveScreenShareSender();
+
+        if (!currentUserId) {
+            resetSelfStreamViewerState();
+            return;
+        }
+
+        if (!stream || stream.ownerId !== currentUserId) {
+            if (
+                hasTrackedScreenShareSender &&
+                selfStreamViewerMonitorState.streamIdentity &&
+                selfStreamViewerMonitorState.viewerCount > 0
+            ) {
+                selfStreamViewerMonitorState.rejoinArmed = true;
+                selfStreamViewerMonitorState.viewerCount = 0;
+                clearViewerRejoinRecoveryTimer();
+                return;
+            }
+
+            if (hasTrackedScreenShareSender && selfStreamViewerMonitorState.streamIdentity) {
+                return;
+            }
+
+            resetSelfStreamViewerState();
+            return;
+        }
+
+        const streamIdentity = getApplicationStreamIdentity(stream);
+        if (!streamIdentity) {
+            if (hasTrackedScreenShareSender && selfStreamViewerMonitorState.streamIdentity) {
+                return;
+            }
+
+            resetSelfStreamViewerState();
+            return;
+        }
+
+        const viewerIds = streamingStore.getViewerIds?.(stream) ?? [];
+        const viewerCount = viewerIds.length;
+
+        if (selfStreamViewerMonitorState.streamIdentity !== streamIdentity) {
+            clearViewerRejoinRecoveryTimer();
+            selfStreamViewerMonitorState.hadViewer = viewerCount > 0;
+            selfStreamViewerMonitorState.rejoinArmed = false;
+            selfStreamViewerMonitorState.streamIdentity = streamIdentity;
+            selfStreamViewerMonitorState.viewerCount = viewerCount;
+            return;
+        }
+
+        const previousViewerCount = selfStreamViewerMonitorState.viewerCount;
+        selfStreamViewerMonitorState.viewerCount = viewerCount;
+
+        if (previousViewerCount > 0 && viewerCount === 0) {
+            selfStreamViewerMonitorState.rejoinArmed = true;
+            clearViewerRejoinRecoveryTimer();
+            return;
+        }
+
+        if (previousViewerCount === 0 && viewerCount > 0) {
+            const recoveryReason = selfStreamViewerMonitorState.hadViewer ? "viewer-rejoin" : "viewer-attach";
+            selfStreamViewerMonitorState.rejoinArmed = false;
+            scheduleViewerAudienceRecovery(recoveryReason, streamIdentity);
+        }
+
+        if (viewerCount > 0) {
+            selfStreamViewerMonitorState.hadViewer = true;
+        }
+    } catch (error) {
+        logger.error("Failed to evaluate screenshare viewer state", error);
+    }
+}
+
+function attachPeerConnectionFixes() {
+    const originalAddTrack = RTCPeerConnection.prototype.addTrack;
+    RTCPeerConnection.prototype.addTrack = function (track, ...streams) {
+        const sender = originalAddTrack.call(this, track, ...streams);
+        attachManagedScreenShareSender(this, sender, track);
+        return sender;
+    };
+
+    const originalAddTransceiver = RTCPeerConnection.prototype.addTransceiver;
+    RTCPeerConnection.prototype.addTransceiver = function (trackOrKind, init) {
+        const transceiver =
+            init === void 0
+                ? originalAddTransceiver.call(this, trackOrKind)
+                : originalAddTransceiver.call(this, trackOrKind, init);
+
+        attachManagedScreenShareSender(this, transceiver.sender, typeof trackOrKind === "string" ? null : trackOrKind);
+        return transceiver;
+    };
+
+    const originalReplaceTrack = RTCRtpSender.prototype.replaceTrack;
+    RTCRtpSender.prototype.replaceTrack = function (track) {
+        const isRecoveryManagedReplace = recoveryManagedReplaceTrackSenders.has(this);
+        const previousTrack = this.track;
+
+        if (!track || !isManagedScreenShareTrack(track)) {
+            senderRecoveryStates.delete(this);
+        } else {
+            rememberManagedScreenShareModeTrack(track);
+
+            if (previousTrack) {
+                rememberLocalConnectionTrack(track, trackLocalConnectionHints.get(previousTrack));
+            }
+
+            if (!isRecoveryManagedReplace) {
+                scheduleCurrentUserScreenShareVideoStreamParameterSync();
+            }
+        }
+
+        if (isManagedScreenShareTrack(track)) {
+            const pc = senderPeerConnections.get(this);
+            if (pc) {
+                trackPeerConnection(pc);
+            }
+        }
+
+        const replaceTrackResult = originalReplaceTrack.call(this, track);
+
+        if (track && isManagedScreenShareTrack(track) && !isRecoveryManagedReplace) {
+            void Promise.resolve(replaceTrackResult)
+                .then(async () => {
+                    await syncManagedScreenShareTrackConstraints(track, findLocalStreamConnection(track), true);
+                    await syncManagedScreenShareSenderParameters(this);
+                })
+                .catch(error => logger.error("Failed to resync screenshare sender after replaceTrack", error));
+        }
+
+        return replaceTrackResult;
+    };
+}
+
+function buildDisplayMediaRequestOptions(opts: DisplayMediaStreamOptionsLike | undefined, desiredContentHint: string) {
+    if (desiredContentHint !== "detail" && desiredContentHint !== "motion") {
+        return opts;
+    }
+
+    const nextOptions = { ...(opts ?? {}) } as DisplayMediaStreamOptionsLike;
+    if (nextOptions.video === false) {
+        return opts;
+    }
+
+    const baseVideoConstraints =
+        typeof nextOptions.video === "object" && nextOptions.video !== null ? nextOptions.video : {};
+
+    nextOptions.video = buildManagedScreenShareRequestConstraints(
+        baseVideoConstraints,
+        getSelectedScreenShareProfile()
+    );
+    return nextOptions;
+}
+
 if (isLinux) {
-    const original = navigator.mediaDevices.getDisplayMedia;
+    attachPeerConnectionFixes();
+
+    onceReady.then(() => {
+        if (!FluxDispatcher?.subscribe) {
+            logger.error("FluxDispatcher unavailable for screenshare remote sink monitoring");
+            return;
+        }
+
+        FluxDispatcher.subscribe("STREAM_CLOSE", ({ streamKey }: { streamKey: string }) => {
+            const owner = streamKey.split(":").at(-1);
+
+            if (owner === UserStore.getCurrentUser()?.id) {
+                resetSelfStreamViewerState();
+            }
+        });
+
+        FluxDispatcher.subscribe("RTC_CONNECTION_REMOTE_VIDEO_SINK_WANTS", (action: RemoteVideoSinkWantsAction) => {
+            handleRemoteVideoSinkWants(action);
+        });
+    });
+
+    waitFor(filters.byStoreName("ApplicationStreamingStore"), store => {
+        const streamingStore = store as ApplicationStreamingStoreLike;
+
+        if (typeof streamingStore.addChangeListener === "function") {
+            streamingStore.addChangeListener(() => handleSelfStreamViewerStateChange(streamingStore));
+        }
+
+        handleSelfStreamViewerStateChange(streamingStore);
+    });
+
+    State.addGlobalChangeListener((_data, path) => {
+        if (path !== "screenshareQuality" && !path.startsWith("screenshareQuality.")) {
+            return;
+        }
+
+        scheduleCurrentUserScreenShareVideoStreamParameterSync();
+        scheduleActiveScreenShareTrackSync(true);
+    });
+
+    const originalGetDisplayMedia = navigator.mediaDevices.getDisplayMedia;
 
     async function getVirtmic() {
         try {
             const devices = await navigator.mediaDevices.enumerateDevices();
             const audioDevice = devices.find(({ label }) => label === "vencord-screen-share");
             return audioDevice?.deviceId;
-        } catch (error) {
+        } catch {
             return null;
         }
     }
 
     navigator.mediaDevices.getDisplayMedia = async function (opts) {
-        const stream = await original.call(this, opts);
+        const desiredContentHint =
+            typeof currentSettings?.contentHint === "string" ? currentSettings.contentHint : "detail";
+        resetSelfStreamViewerState();
+        const stream = await originalGetDisplayMedia.call(
+            this,
+            buildDisplayMediaRequestOptions(opts, desiredContentHint)
+        );
         const id = await getVirtmic();
+        const [track] = stream.getVideoTracks();
 
-        const frameRate = Number(State.store.screenshareQuality?.frameRate ?? 30);
-        const height = Number(State.store.screenshareQuality?.resolution ?? 720);
-        const width = Math.round(height * (16 / 9));
-        const track = stream.getVideoTracks()[0];
+        if (!track) {
+            return stream;
+        }
 
-        track.contentHint = String(currentSettings?.contentHint);
+        track.contentHint = desiredContentHint;
 
-        const constraints = {
-            ...track.getConstraints(),
-            frameRate: { min: frameRate, ideal: frameRate },
-            width: { min: 640, ideal: width, max: width },
-            height: { min: 480, ideal: height, max: height },
-            advanced: [{ width: width, height: height }],
-            resizeMode: "none"
-        };
+        rememberManagedScreenShareModeTrack(track);
 
-        track
-            .applyConstraints(constraints)
-            .then(() => {
-                logger.info("Applied constraints successfully. New constraints: ", track.getConstraints());
-            })
-            .catch(e => logger.error("Failed to apply constraints.", e));
+        scheduleCurrentUserScreenShareVideoStreamParameterSync();
+        scheduleActiveScreenShareTrackSync();
+        void syncManagedScreenShareTrackConstraints(track, null, true);
 
         if (id) {
             const audio = await navigator.mediaDevices.getUserMedia({
@@ -66,8 +1719,11 @@ if (isLinux) {
                 }
             });
 
-            stream.getAudioTracks().forEach(t => stream.removeTrack(t));
-            stream.addTrack(audio.getAudioTracks()[0]);
+            const [audioTrack] = audio.getAudioTracks();
+            if (audioTrack) {
+                stream.getAudioTracks().forEach(track => stream.removeTrack(track));
+                stream.addTrack(audioTrack);
+            }
         }
 
         return stream;


### PR DESCRIPTION
## Summary
- keep the selected Linux screenshare profile aligned across capture constraints, `videoStreamParameters`, and RTP sender parameters
- resync the active screenshare path after stream start, profile changes, and `replaceTrack()`
- add a guarded recovery path for viewer attach/rejoin when the outbound sender still appears stalled after the normal resync path

## Context
This started from Linux NVIDIA VAAPI/NVENC validation, especially `Prefer Clarity` sessions.

Before this patch, that setup could not reliably recover viewer attach/rejoin. The sender could remain alive while the effective screenshare state drifted across capture constraints, connection stream parameters, and RTP sender configuration.

Related driver-side validation context:
- https://github.com/elFarto/nvidia-vaapi-driver/pull/425

## Notes
The failure was first reproduced during NVIDIA VAAPI validation, but the fix belongs in Vesktop's Linux screenshare path rather than in a vendor-specific branch.

The recovery path is intentionally conservative. It first reapplies the selected profile and resynchronizes sender state, then only escalates to `replaceTrack()`-based recovery if the sender still appears unhealthy after that safer resync step.

This patch only changes Linux behavior.
