### PR TITLE
fix: restore window state before showing on FOCUS event

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -107,7 +107,11 @@ function getWindow(e: IpcMainInvokeEvent, key?: string) {
 }
 
 handle(IpcEvents.FOCUS, () => {
+    if (mainWin.isMinimized()) {
+        mainWin.restore();
+    }
     mainWin.show();
+    mainWin.focus();
     mainWin.setSkipTaskbar(false);
 });
 


### PR DESCRIPTION
Fix for https://github.com/Vencord/Vesktop/issues/464
This change ensures the window's state is restored before handling the FOCUS event, preventing the incorrect window sizing behavior.
Unfortunately, I was not able to test how this behaves, or whether it causes any issues on non-Windows systems.