### PR TITLE
Auto-reload renderer when it crashes

### DIFF
--- a/src/main/mainWindow.ts
+++ b/src/main/mainWindow.ts
@@ -38,6 +38,7 @@ import { downloadVencordFiles, ensureVencordFiles, vencordSupportsSandboxing } f
 import { VENCORD_FILES_DIR } from "./vencordFilesDir";
 
 let isQuitting = false;
+let lastRendererCrashAt = 0;
 
 applyDeckKeyboardFix();
 
@@ -485,6 +486,25 @@ export async function createWindows() {
         }
     });
 
-    mainWin.webContents.on("render-process-gone", (event, details) => console.log(details));
+    mainWin.webContents.on("render-process-gone", (_, details) => {
+        console.error("Renderer process gone:", details);
+
+        // Only auto-reload on actual crashes, not clean exits or user-initiated kills.
+        // See https://www.electronjs.org/docs/latest/api/web-contents#event-render-process-gone
+        const recoverableReasons = new Set(["crashed", "oom", "abnormal-exit"]);
+        if (!recoverableReasons.has(details.reason)) return;
+
+        // Loop-breaker: if we crashed again within 30s of the last crash, give up
+        // so a renderer that crashes on load doesn't reload forever.
+        const now = Date.now();
+        if (now - lastRendererCrashAt < 30_000) {
+            console.error("Renderer crashed twice within 30s; not auto-reloading");
+            return;
+        }
+        lastRendererCrashAt = now;
+
+        console.log("Auto-reloading renderer after crash");
+        mainWin.webContents.reload();
+    });
     initArRPC();
 }


### PR DESCRIPTION
## Summary

When Vesktop's renderer process dies (commonly during long screen-share sessions, see #792), the main Electron process keeps running but the window appears frozen because there's no UI to update. The existing `render-process-gone` handler only logs the event:

```ts
mainWin.webContents.on("render-process-gone", (event, details) => console.log(details));
```

This PR makes that handler reload the renderer when the failure looks recoverable, so the user gets a brief interruption instead of a dead window that requires a full app restart.

## Diagnostic evidence

Captured from a session that froze after ~20 minutes of full-screen 4K streaming on NVIDIA + Wayland (Hyprland), running Vesktop with `--enable-logging=stderr --v=1`:

**The renderer crashed — it didn't just hang:**

```
[2791694:0426/025109.179228:VERBOSE1:.../media_stream_manager.cc:1589] AOC::StopStream => (error_during_callback=false)
Renderer process crashed - see https://www.electronjs.org/docs/tutorial/application-debugging for potential debugging information.
[2791694:0426/025109.194965:INFO:.../shared_screencast_stream.cc:253] PipeWire stream state: paused
[2791694:0426/025109.195025:INFO:.../shared_screencast_stream.cc:253] PipeWire stream state: unconnected
```

**`ps` after the freeze confirms the renderer process is gone** while the main Electron process is still alive in `do_sys_poll` — exactly the state that produces a "frozen window" from the user's POV.

**WebRTC was already starving for ~20 min before the crash** (3840×2160 input, only ~7 fps making it out, ~60% drop rate sustained):

```
VAdapt Drop Frame: scaled 0 / out 26905 / in 65515 ... Input: 3840x2160 ... Output fps: 7
```

So the failure mode is: capture/encode pipeline overload → renderer becomes unresponsive → Chromium kills it → main process has nothing to draw → window appears frozen until full app restart.

VRAM was stable (~5 GB / 6 GB free) the whole time — this is not OOM, it's the renderer-watchdog killing an unresponsive process.

## Behavior

- **Auto-reloads** on `crashed`, `oom`, `abnormal-exit`.
- **Doesn't reload** on `clean-exit`, `killed`, `launch-failed`, `integrity-failure` (where reload is wrong or unsafe).
- **Loop-breaker:** if a second crash happens within 30s of the previous one, gives up so a renderer that crashes on load can't reload forever.
- Logs both the crash details and the reload attempt at error/info level.

## Why this is worth shipping even without a root-cause fix for #792

The actual cause (Chromium's capture pipeline + NVIDIA Wayland encode being too slow to keep up at high resolutions) is upstream Electron / driver territory and the maintainer position on similar issues (#320) has been "wait for electron." That's reasonable.

But it leaves users with a UX where a 30+ minute stream silently turns into a dead window with no indication of what happened. This patch doesn't fix the cause — it just makes the failure mode recoverable: stream blips for a couple seconds, renderer comes back, user knows what happened. Tiny surface area, low risk.

## Test plan

- [ ] Stream a screen long enough (or under enough load) to trigger a renderer crash; confirm the window auto-reloads instead of freezing.
- [ ] Force a renderer crash via DevTools (`process.crash()` in the renderer) and confirm reload.
- [ ] Verify normal app close still works (no spurious reload on `clean-exit`).
- [ ] Verify CI build passes.