### PR TITLE
fix DTLS Connecting issues for users of tailscale or similar VPNs

### DIFF
--- a/src/main/mainWindow.ts
+++ b/src/main/mainWindow.ts
@@ -409,6 +409,9 @@ function createMainWindow() {
 
     win.webContents.setUserAgent(BrowserUserAgent);
 
+    // Fixes voice/video calls hanging at DTLS Connecting when using VPNs like Tailscale
+    win.webContents.setWebRTCIPHandlingPolicy("default_public_and_private_interfaces");
+
     // if the open-url event is fired (in index.ts) while starting up, darwinURL will be set. If not fall back to checking the process args (which Windows and Linux use for URI calling.)
     // win.webContents.session.clearCache().then(() => {
     loadUrl(darwinURL || process.argv.find(arg => arg.startsWith("discord://")));


### PR DESCRIPTION
This changes the WebRTC IP handling policy to ignore non-default routes.

When running Tailscale, WebRTC can sometimes get confused and bind to that private VPN interface, hanging forever on DTLS Connecting.
This change, from my understanding, makes WebRTC only bind to the default route interface which is likely the intended behaviour anyway, avoiding weird issues with tailscale.

fixes https://github.com/Vencord/Vesktop/issues/876