### PR TITLE
screenShare: skip duplicate portal chooser on Wayland

### DIFF
--- a/src/main/screenShare.ts
+++ b/src/main/screenShare.ts
@@ -58,7 +58,15 @@ export function registerScreenShareHandler() {
                 if (stream === null) return callback({});
             }
 
-            callback(video ? { video: sources[0] } : {});
+            // Workaround for electron/electron#30652: Chromium's
+            // WebRTCPipeWireCapturer creates a fresh portal session in Start()
+            // that is independent from the one desktopCapturer.getSources just
+            // used. On non-GNOME compositors (niri, hyprland, sway) this
+            // surfaces as TWO portal chooser dialogs. Passing a synthetic
+            // source ID here lets PipeWire's portal show its picker only
+            // once, when the actual stream starts.
+            const placeholder = { id: "screen:0:0", name: "Entire Screen" } as Electron.DesktopCapturerSource;
+            callback(video ? { video: placeholder } : {});
             return;
         }
 


### PR DESCRIPTION
## Summary

On non-GNOME Wayland compositors (niri, hyprland, sway, labwc) Vesktop currently shows the xdg-desktop-portal chooser dialog **twice** in a row when a user clicks "Share Screen":

1. First chooser: triggered by `desktopCapturer.getSources()` enumerating sources for Vesktop's preview thumbnails
2. Second chooser: triggered by Chromium's `WebRTCPipeWireCapturer.Start()` when `setDisplayMediaRequestHandler`'s callback fires — this opens a fresh portal session independent from the first one

GNOME's portal silently auto-restores the second session via its in-memory token, masking the issue. Other portals show the dialog twice.

## Fix

On Wayland, pass a synthetic `{ id: "screen:0:0", name: "Entire Screen" }` source to the `displayMediaRequestHandler` callback instead of the real Source object from `getSources()`. Chromium's PipeWire capturer ignores Vesktop-side source IDs on Wayland (it always opens its own portal session for the actual stream regardless), so the synthetic ID is harmless — and PipeWire's portal shows its chooser exactly once.

## Test plan

Tested on niri 26.04 + xdg-desktop-portal-gnome 48 + Vesktop 1.6.5 + Electron 40.4.0 + Chromium 144:
- **Before**: clicking "Share Screen" showed two consecutive GTK4 chooser dialogs; user had to pick a source twice.
- **After**: only one chooser dialog appears; stream starts normally; Discord viewers receive the screenshare.

No regression observed on X11 (the `if (isWayland)` branch is unchanged for non-Wayland).

## Refs

- [electron/electron#30652](https://github.com/electron/electron/issues/30652) — *Redundant app-created screen share dialog on Linux Wayland* (open since 2021)
- [#583](https://github.com/Vencord/Vesktop/issues/583) — Vendicated confirmed Chromium opens two sessions intentionally
- Documented community workaround approach: [comment by xander1421 on electron#30652](https://github.com/electron/electron/issues/30652)