### PR TITLE
Only download required Vencord desktop assets

### DIFF
--- a/src/main/utils/vencordLoader.ts
+++ b/src/main/utils/vencordLoader.ts
@@ -48,13 +48,22 @@ export async function downloadVencordFiles() {
     const release = await githubGet("/repos/Vendicated/Vencord/releases/latest");
 
     const { assets }: ReleaseData = await release.json();
+    const assetsByName = new Map(assets.map(asset => [asset.name, asset]));
+    const missingAssets = FILES_TO_DOWNLOAD.filter(name => !assetsByName.has(name));
+
+    if (missingAssets.length) throw new Error(`Vencord release is missing assets: ${missingAssets.join(", ")}`);
 
     await Promise.all(
-        assets
-            .filter(({ name }) => FILES_TO_DOWNLOAD.some(f => name.startsWith(f)))
-            .map(({ name, browser_download_url }) =>
-                downloadFile(browser_download_url, join(VENCORD_FILES_DIR, name), {}, { retryOnNetworkError: true })
+        FILES_TO_DOWNLOAD.map(name =>
+            downloadFile(
+                assetsByName.get(name)!.browser_download_url,
+                join(VENCORD_FILES_DIR, name),
+                {},
+                {
+                    retryOnNetworkError: true
+                }
             )
+        )
     );
 }
 


### PR DESCRIPTION
### Repro

1. Open Vesktop on macOS.
2. Use Vesktop > Force Update Vencord.
3. Hit a Vencord asset download failure.
4. Relaunch Vesktop.

On my machine, this left `~/Library/Application Support/vesktop/sessionData/vencordFiles` with only `package.json`. Startup logs then retried `vencordDesktop*.map` and `.LEGAL.txt` downloads, and Vesktop stayed alive with no main window.

### Change

`downloadVencordFiles()` now maps release assets by exact filename and downloads only the four files `isValidVencordInstall()` checks. It also throws a named missing-asset error if the release lacks one of those files.
