### PR TITLE
Handle discord:// URLs when Vesktop is already running

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -11,10 +11,12 @@ import "./userAssets";
 import "./vesktopProtocol";
 
 import { app, BrowserWindow, nativeTheme } from "electron";
+import { IpcCommands } from "shared/IpcEvents";
 
 import { DATA_DIR } from "./constants";
 import { createFirstLaunchTour } from "./firstLaunch";
-import { createWindows, mainWin } from "./mainWindow";
+import { sendRendererCommand } from "./ipcCommands";
+import { createWindows, loadUrl, mainWin } from "./mainWindow";
 import { registerMediaPermissionsHandler } from "./mediaPermissions";
 import { registerScreenShareHandler } from "./screenShare";
 import { Settings, State } from "./settings";
@@ -101,12 +103,15 @@ function init() {
     // In the Flatpak on SteamOS the theme is detected as light, but SteamOS only has a dark mode, so we just override it
     if (isDeckGameMode) nativeTheme.themeSource = "dark";
 
-    app.on("second-instance", (_event, _cmdLine, _cwd, data: any) => {
+    app.on("second-instance", (_event, cmdLine, _cwd, data: any) => {
         if (data.IS_DEV) app.quit();
         else if (mainWin) {
             if (mainWin.isMinimized()) mainWin.restore();
             if (!mainWin.isVisible()) mainWin.show();
             mainWin.focus();
+
+            const url = cmdLine.find(arg => arg.startsWith("discord://"));
+            if (url) handleProtocolUrl(url);
         }
     });
 
@@ -147,8 +152,30 @@ async function bootstrap() {
 // MacOS only event
 export let darwinURL: string | undefined;
 app.on("open-url", (_, url) => {
-    darwinURL = url;
+    // Until the main window exists, stash the URL so the initial loadUrl call picks it up.
+    // After that, route through the renderer so we don't reload the entire client.
+    if (mainWin) handleProtocolUrl(url);
+    else darwinURL = url;
 });
+
+async function handleProtocolUrl(url: string) {
+    let parsed: URL;
+    try {
+        parsed = new URL(url);
+    } catch {
+        return;
+    }
+    if (parsed.protocol !== "discord:") return;
+
+    // Canonical form is discord://-/<path> — the "-" is a placeholder host.
+    const inviteMatch = parsed.pathname.match(/^\/invite\/([\w-]+)\/?$/);
+    if (inviteMatch) {
+        const handled = await sendRendererCommand(IpcCommands.RPC_INVITE, inviteMatch[1]).catch(() => false);
+        if (handled) return;
+    }
+
+    loadUrl(url);
+}
 
 app.on("window-all-closed", () => {
     if (process.platform !== "darwin") app.quit();


### PR DESCRIPTION
## Summary

`discord://` invite links are dropped on the floor when Vesktop is already running — the window focuses but no join modal appears. This fixes that for both Linux/Windows (via `second-instance`) and macOS (via post-startup `open-url`).

## Background

#813 added `discord://` URL handling, but only at first launch:

- `createMainWindow()` reads `process.argv` / `darwinURL` and calls `loadUrl()` once.
- The `second-instance` handler in `src/main/index.ts` ignored `cmdLine` entirely (`_cmdLine`).
- The `open-url` handler only stashed the URL into `darwinURL`, which is never read after the initial window creation.

Since most users have Vesktop already running when they click an invite, this is the common path.

## Fix

Both `second-instance` and `open-url` now funnel through a new `handleProtocolUrl()` helper. For `discord://-/invite/CODE` URLs it sends the code via the existing `RPC_INVITE` IPC, which `src/renderer/arrpc.ts` already wires to `InviteActions.resolveInvite` + `INVITE_MODAL_OPEN` — so the join modal pops up without reloading the entire Discord client (preserves voice connection, scroll state, etc.). Non-invite deep links fall back to `loadUrl()` to match the existing first-launch behavior.

## Test plan

- [x] Start Vesktop, then from another terminal: `xdg-open 'discord://-/invite/YVbdG2ZRG4'` — join modal opens, no client reload
- [ ] Same on Windows (clicking an invite link in a browser while Vesktop is open)
- [ ] Same on macOS
- [ ] Cold start (Vesktop closed) still works as before — `loadUrl` path unchanged
- [x] `pnpm testTypes` and `pnpm lint` pass