### PR TITLE
include child process audio nodes when sharing app sound

### DIFF
--- a/src/main/venmic.ts
+++ b/src/main/venmic.ts
@@ -6,6 +6,7 @@
 
 import type { LinkData, Node, PatchBay as PatchBayType } from "@vencord/venmic";
 import { app, ipcMain } from "electron";
+import { readFileSync } from "fs";
 import { join } from "path";
 import { IpcEvents } from "shared/IpcEvents";
 import { STATIC_DIR } from "shared/paths";
@@ -66,6 +67,68 @@ function getRendererAudioServicePid() {
     );
 }
 
+function getPpid(pid: string): string | undefined {
+    try {
+        return readFileSync(`/proc/${pid}/status`, "utf8").match(/^PPid:\s*(\d+)/m)?.[1];
+    } catch {
+        return undefined;
+    }
+}
+
+// Walks pid's ancestry; returns the topmost PID that itself owns an audio node.
+// Used to group child audio processes (e.g. FMOD subprocess) under their parent app.
+function findGroupRoot(pid: string, audioPids: Set<string>): string {
+    let root = pid;
+    let cur: string | undefined = pid;
+    for (let depth = 0; depth < 16; depth++) {
+        const ppid = getPpid(cur);
+        if (!ppid || ppid === "0" || ppid === cur) break;
+        if (audioPids.has(ppid)) root = ppid;
+        cur = ppid;
+    }
+    return root;
+}
+
+function nodeMatchesFilter(filter: Node, node: Node): boolean {
+    return Object.keys(filter).every(k => (filter as any)[k] === (node as any)[k]);
+}
+
+function expandWithProcessGroup(filters: Node[], audioPid: string): Node[] {
+    const venmic = obtainVenmic();
+    if (!venmic) return filters;
+
+    const all = venmic.list().filter(s => s["application.process.id"] !== audioPid);
+    const audioPids = new Set<string>();
+    for (const n of all) {
+        const p = n["application.process.id"];
+        if (p) audioPids.add(p);
+    }
+    if (audioPids.size === 0) return filters;
+
+    const groupRoot = new Map<string, string>();
+    for (const p of audioPids) groupRoot.set(p, findGroupRoot(p, audioPids));
+
+    const wantedRoots = new Set<string>();
+    for (const f of filters) {
+        for (const n of all) {
+            const p = n["application.process.id"];
+            if (p && nodeMatchesFilter(f, n)) wantedRoots.add(groupRoot.get(p)!);
+        }
+    }
+    if (wantedRoots.size === 0) return filters;
+
+    const extras: Node[] = [];
+    for (const n of all) {
+        const p = n["application.process.id"];
+        if (!p) continue;
+        const root = groupRoot.get(p);
+        if (!root || !wantedRoots.has(root)) continue;
+        if (filters.some(f => nodeMatchesFilter(f, n))) continue;
+        extras.push({ "application.process.id": p } as Node);
+    }
+    return extras.length ? [...filters, ...extras] : filters;
+}
+
 ipcMain.handle(IpcEvents.VIRT_MIC_LIST, () => {
     const audioPid = getRendererAudioServicePid();
 
@@ -80,10 +143,10 @@ ipcMain.handle(IpcEvents.VIRT_MIC_LIST, () => {
 
 ipcMain.handle(IpcEvents.VIRT_MIC_START, (_, include: Node[]) => {
     const pid = getRendererAudioServicePid();
-    const { ignoreDevices, ignoreInputMedia, ignoreVirtual, workaround } = Settings.store.audio ?? {};
+    const { ignoreDevices, ignoreInputMedia, ignoreVirtual, workaround, granularSelect } = Settings.store.audio ?? {};
 
     const data: LinkData = {
-        include,
+        include: granularSelect ? include : expandWithProcessGroup(include, pid),
         exclude: [{ "application.process.id": pid }],
         ignore_devices: ignoreDevices
     };
@@ -106,12 +169,21 @@ ipcMain.handle(IpcEvents.VIRT_MIC_START, (_, include: Node[]) => {
 ipcMain.handle(IpcEvents.VIRT_MIC_START_SYSTEM, (_, exclude: Node[]) => {
     const pid = getRendererAudioServicePid();
 
-    const { workaround, ignoreDevices, ignoreInputMedia, ignoreVirtual, onlySpeakers, onlyDefaultSpeakers } =
-        Settings.store.audio ?? {};
+    const {
+        workaround,
+        ignoreDevices,
+        ignoreInputMedia,
+        ignoreVirtual,
+        onlySpeakers,
+        onlyDefaultSpeakers,
+        granularSelect
+    } = Settings.store.audio ?? {};
+
+    const expandedExclude = granularSelect ? exclude : expandWithProcessGroup(exclude, pid);
 
     const data: LinkData = {
         include: [],
-        exclude: [{ "application.process.id": pid }, ...exclude],
+        exclude: [{ "application.process.id": pid }, ...expandedExclude],
         only_speakers: onlySpeakers,
         ignore_devices: ignoreDevices,
         only_default_speakers: onlyDefaultSpeakers


### PR DESCRIPTION
When sharing audio from an app whose audio plays through a child process (e.g. Rhythia's FMOD subprocess), only the directly selected node was linked, so the actual audio never made it into the stream. Walk PPid via /proc/<pid>/status to group sibling audio nodes under their topmost audio-owning ancestor and expand include/exclude filters to cover the whole group. Skipped when granular selection is on.