### PR TITLE
Fix screenshare timeout and memory leaks

### DIFF
--- a/src/main/screenShare.ts
+++ b/src/main/screenShare.ts
@@ -19,22 +19,21 @@ export function registerScreenShareHandler() {
         const sources = await desktopCapturer.getSources({
             types: ["window", "screen"],
             thumbnailSize: {
-                width: 1920,
-                height: 1080
+                width: 1280,
+                height: 720
             }
         });
         return sources.find(s => s.id === id)?.thumbnail.toDataURL();
     });
 
     session.defaultSession.setDisplayMediaRequestHandler(async (request, callback) => {
-        // request full resolution on wayland right away because we always only end up with one result anyway
-        const width = isWayland ? 1920 : 176;
+        const width = isWayland ? 320 : 176;
         const sources = await desktopCapturer
             .getSources({
                 types: ["window", "screen"],
                 thumbnailSize: {
                     width,
-                    height: width * (9 / 16)
+                    height: Math.round(width * (9 / 16))
                 }
             })
             .catch(err => console.error("Error during screenshare picker", err));
@@ -49,16 +48,16 @@ export function registerScreenShareHandler() {
 
         if (isWayland) {
             const video = data[0];
-            if (video) {
-                const stream = await sendRendererCommand<StreamPick>(IpcCommands.SCREEN_SHARE_PICKER, {
-                    screens: [video],
-                    skipPicker: true
-                }).catch(() => null);
+            if (!video) return callback({});
 
-                if (stream === null) return callback({});
-            }
+            const stream = await sendRendererCommand<StreamPick>(IpcCommands.SCREEN_SHARE_PICKER, {
+                screens: [video],
+                skipPicker: true
+            }).catch(() => null);
 
-            callback(video ? { video: sources[0] } : {});
+            if (stream === null) return callback({});
+
+            callback({ video: sources[0] });
             return;
         }
 

--- a/src/renderer/components/ScreenSharePicker.tsx
+++ b/src/renderer/components/ScreenSharePicker.tsx
@@ -772,7 +772,8 @@ function ModalComponent({
                                 );
                                 if (!conn) return;
 
-                                const track = conn.input.stream.getVideoTracks()[0];
+                                const track = conn.input?.stream?.getVideoTracks()[0];
+                                if (!track) return;
 
                                 const constraints = {
                                     ...track.getConstraints(),

--- a/src/renderer/patches/screenShareFixes.ts
+++ b/src/renderer/patches/screenShareFixes.ts
@@ -33,6 +33,8 @@ if (isLinux) {
         const width = Math.round(height * (16 / 9));
         const track = stream.getVideoTracks()[0];
 
+        if (!track) return stream;
+
         track.contentHint = String(currentSettings?.contentHint);
 
         const constraints = {
@@ -66,8 +68,17 @@ if (isLinux) {
                 }
             });
 
-            stream.getAudioTracks().forEach(t => stream.removeTrack(t));
-            stream.addTrack(audio.getAudioTracks()[0]);
+            const audioTrack = audio.getAudioTracks()[0];
+            stream.getAudioTracks().forEach(t => {
+                t.stop();
+                stream.removeTrack(t);
+            });
+            stream.addTrack(audioTrack);
+
+            track.addEventListener("ended", () => {
+                audioTrack.stop();
+                audio.getTracks().forEach(t => t.stop());
+            }, { once: true });
         }
 
         return stream;


### PR DESCRIPTION
## Summary
- **Fix screenshare timeout**: Reduced thumbnail sizes in the screen picker flow to prevent Discord from timing out while waiting for the Electron media handler callback. Wayland picker thumbnails reduced from 1920x1080 to 320x180 (auto-selected source doesn't need a high-res preview). Large preview thumbnails reduced from 1920x1080 to 1280x720.
- **Fix audio stream memory leak**: Audio tracks from `getUserMedia` were removed from the stream without calling `.stop()`, leaving native audio pipelines open across sessions. Now properly stops tracks and cleans up via a `once` listener on the video track's `ended` event.
- **Fix null-safety crash**: Added optional chaining for `conn.input?.stream?.getVideoTracks()` in the post-submit constraint application, preventing crashes when the connection isn't fully established.

## Memory impact
- Wayland thumbnail memory (20 windows): ~158 MB → ~4.5 MB (~97% reduction)
- Large preview thumbnail: ~7.9 MB → ~3.5 MB per fetch
- Audio stream leak: eliminated (tracks now properly stopped on stream end)

## Test plan
- [ ] Start screenshare on Wayland — should not timeout or show infinite loading
- [ ] Start screenshare on X11 — picker should work normally with lower-res preview
- [ ] Share screen with audio on Linux — verify audio works and no resource leak on stop
- [ ] Start/stop screenshare multiple times — verify no memory growth via DevTools

🤖 Generated with [Claude Code](https://claude.com/claude-code)