### PR TITLE
fix: route flatpak autostart through startvesktop wrapper

### DIFF
--- a/src/main/autoStart.ts
+++ b/src/main/autoStart.ts
@@ -21,6 +21,16 @@ interface AutoStart {
 }
 
 function getEscapedCommandLine() {
+    // Inside a flatpak, process.argv[0] is /app/bin/vesktop/vesktop.bin (the raw Electron
+    // binary that startvesktop+zypak invoke). The Background portal writes argv[0] as
+    // `flatpak run --command=...`, which would bypass the startvesktop wrapper (and zypak)
+    // and crash Chromium with a SUID-sandbox FATAL on next login. Use the manifest's
+    // default command name instead.
+    if (IS_FLATPAK) {
+        const args = ["startvesktop"];
+        if (Settings.store.autoStartMinimized) args.push("--start-minimized");
+        return args.map(escapeDesktopFileArgument);
+    }
     const args = process.argv.map(escapeDesktopFileArgument);
     if (Settings.store.autoStartMinimized) args.push("--start-minimized");
     return args;


### PR DESCRIPTION
## Symptom

In a flatpak install, toggling "Start With System" succeeds and writes `~/.config/autostart/dev.vencord.Vesktop.desktop`, but the autostart unit crashes Chromium on next login:

```
FATAL:sandbox/linux/suid/client/setuid_sandbox_host.cc:166
The SUID sandbox helper binary was found, but is not configured correctly.
Rather than run without sandboxing I'm aborting now. You need to make sure
that /app/bin/vesktop/chrome-sandbox is owned by root and has mode 4755.
```

`systemd-xdg-autostart-generator`'s unit reports `status=133/n/a`. Launching Vesktop manually still works because the launcher uses the canonical `.desktop` with `--command=startvesktop`.

## Root cause

#1180 introduced `makeAutoStartLinuxPortal()` and reused the existing `getEscapedCommandLine()` helper for both code paths. For the local-file path (non-flatpak), returning `process.argv` is correct: it becomes the literal `Exec=` line.

For the portal path, the array is fed to `org.freedesktop.portal.Background.RequestBackground`'s `commandline` option. xdg-desktop-portal's flatpak handler (`src/xdp-app-info-flatpak.c:248-291` `rewrite_commandline`) emits:

```
flatpak run --command=<argv[0]> <appid> <argv[1:]>
```

Inside the flatpak sandbox, `process.argv[0]` is `/app/bin/vesktop/vesktop.bin` (the raw Electron binary that `startvesktop` then `zypak-wrapper` invoke), not the wrapper. So `--command=` is wired to the post-zypak binary, bypassing zypak entirely. Verified via `/proc/<pid>/cmdline` of a running `vesktop.bin`:

```
/app/bin/vesktop/vesktop.bin
--enable-speech-dispatcher
```

## Fix

Hardcode the manifest's default command name (`startvesktop`) as `commandline[0]` on the flatpak path. The portal then writes:

```
Exec=flatpak run --command=startvesktop dev.vencord.Vesktop [--start-minimized]
```

Identical in shape to the canonical `.desktop` file's command (sans `--file-forwarding`, which is irrelevant at autostart time since no URL is passed). The non-flatpak path is unchanged.

## Verification

Built a flatpak from this patch locally (`flatpak-builder` against the flathub manifest, AppImage source swapped for one built from `pnpm package --linux AppImage` on this branch). Toggled "Start With System" off then on inside the patched build. Resulting autostart:

```
Exec=flatpak run --command=startvesktop dev.vencord.Vesktop --start-minimized
```

Triggered the regenerated `app-dev.vencord.Vesktop@autostart.service` unit cold. Process tree confirms zypak routing:

```
bwrap --args N -- startvesktop --start-minimized
/app/bin/vesktop/vesktop.bin --enable-speech-dispatcher --start-minimized
/app/bin/vesktop/vesktop.bin --type=zygote --no-zygote-sandbox
bwrap --args N -- /app/bin/zypak-helper child - /app/bin/vesktop/vesktop.bin --type=zygote
```

No FATAL, no coredump, unit `active (running)`.

## Notes

The same FATAL string appears in #991 and #1081, but those describe the DEB-package variant where `/opt/Vesktop/chrome-sandbox` loses its setuid bit on package update. Different root cause, different fix. This PR addresses only the flatpak-autostart variant.
