### PR TITLE
Feat/Added a setting to disable the automatic streamer mode from arrpc

### DIFF
--- a/src/renderer/arrpc.ts
+++ b/src/renderer/arrpc.ts
@@ -24,7 +24,7 @@ onIpcCommand(IpcCommands.RPC_ACTIVITY, async jsonData => {
 
     const data = JSON.parse(jsonData);
 
-    if (data.socketId === "STREAMERMODE" && StreamerModeStore.autoToggle) {
+    if (data.socketId === "STREAMERMODE" && StreamerModeStore.autoToggle && Settings.store.automaticStreamer) {
         FluxDispatcher.dispatch({
             type: "STREAMER_MODE_UPDATE",
             key: "enabled",

--- a/src/renderer/components/settings/Settings.tsx
+++ b/src/renderer/components/settings/Settings.tsx
@@ -142,6 +142,14 @@ const SettingsOptions: Record<string, Array<BooleanSetting | SettingsComponent>>
         },
 
         {
+            key: "automaticStreamer",
+            title: "Automatic Streamer mode",
+            description: "Enables streamer mode automatically when OBS is open",
+            defaultValue: true,
+            disabled: () => Settings.store.arRPC === false
+        },
+
+        {
             key: "openLinksWithElectron",
             title: "Open Links in app (experimental)",
             description: "Opens links in a new Vesktop window instead of your web browser",

--- a/src/shared/settings.d.ts
+++ b/src/shared/settings.d.ts
@@ -19,6 +19,7 @@ export interface Settings {
     hardwareAcceleration?: boolean;
     hardwareVideoAcceleration?: boolean;
     arRPC?: boolean;
+    automaticStreamer?: boolean;
     appBadge?: boolean;
     enableTaskbarFlashing?: boolean;
     disableMinSize?: boolean;


### PR DESCRIPTION
It annoyed me quite a bit that all my names were shortened when I just had my replay buffer on, no idea why this is not already implemented