### PR TITLE
Add setting for WebRTCIPHandlingPolicy

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -158,3 +158,15 @@ app.on("open-url", (_, url) => {
 app.on("window-all-closed", () => {
     if (process.platform !== "darwin") app.quit();
 });
+
+// Sets the WebRTC IP handling policy for all current and future windows.
+// Switching to "default_public_and_private_interfaces" may fix calls stuck at "DTLS Connecting" when using VPNs, Tailscale, etc.
+// https://github.com/Vencord/Vesktop/issues/876
+app.on("web-contents-created", (_event, contents) => {
+    contents.setWebRTCIPHandlingPolicy(Settings.store.webRTCIPHandlingPolicy ?? "default");
+});
+Settings.addChangeListener("webRTCIPHandlingPolicy", () => {
+    for (const win of BrowserWindow.getAllWindows()) {
+        win.webContents.setWebRTCIPHandlingPolicy(Settings.store.webRTCIPHandlingPolicy ?? "default");
+    }
+});

--- a/src/main/mainWindow.ts
+++ b/src/main/mainWindow.ts
@@ -409,6 +409,9 @@ function createMainWindow() {
 
     win.webContents.setUserAgent(BrowserUserAgent);
 
+    // Fixes voice/video calls hanging at DTLS Connecting when using VPNs like Tailscale
+    win.webContents.setWebRTCIPHandlingPolicy("default_public_and_private_interfaces");
+
     // if the open-url event is fired (in index.ts) while starting up, darwinURL will be set. If not fall back to checking the process args (which Windows and Linux use for URI calling.)
     // win.webContents.session.clearCache().then(() => {
     loadUrl(darwinURL || process.argv.find(arg => arg.startsWith("discord://")));

--- a/src/main/mainWindow.ts
+++ b/src/main/mainWindow.ts
@@ -409,9 +409,6 @@ function createMainWindow() {
 
     win.webContents.setUserAgent(BrowserUserAgent);
 
-    // Fixes voice/video calls hanging at DTLS Connecting when using VPNs like Tailscale
-    win.webContents.setWebRTCIPHandlingPolicy("default_public_and_private_interfaces");
-
     // if the open-url event is fired (in index.ts) while starting up, darwinURL will be set. If not fall back to checking the process args (which Windows and Linux use for URI calling.)
     // win.webContents.session.clearCache().then(() => {
     loadUrl(darwinURL || process.argv.find(arg => arg.startsWith("discord://")));

--- a/src/renderer/components/settings/Settings.tsx
+++ b/src/renderer/components/settings/Settings.tsx
@@ -9,6 +9,7 @@ import "./settings.css";
 import { classNameFactory } from "@vencord/types/api/Styles";
 import { BaseText, Divider, ErrorBoundary } from "@vencord/types/components";
 import { ComponentType } from "react";
+import { WebRTCIPHandlingPolicyPicker } from "renderer/components/settings/WebRTCIPHandlingPolicyPicker";
 import { Settings, useSettings } from "renderer/settings";
 import { isMac, isWindows } from "renderer/utils";
 
@@ -20,7 +21,6 @@ import { OutdatedVesktopWarning } from "./OutdatedVesktopWarning";
 import { UserAssetsButton } from "./UserAssets";
 import { VesktopSettingsSwitch } from "./VesktopSettingsSwitch";
 import { WindowsTransparencyControls } from "./WindowsTransparencyControls";
-import { WebRTCIPHandlingPolicyPicker } from "renderer/components/settings/WebRTCIPHandlingPolicyPicker";
 
 interface BooleanSetting {
     key: keyof typeof Settings.store;

--- a/src/renderer/components/settings/Settings.tsx
+++ b/src/renderer/components/settings/Settings.tsx
@@ -20,6 +20,7 @@ import { OutdatedVesktopWarning } from "./OutdatedVesktopWarning";
 import { UserAssetsButton } from "./UserAssets";
 import { VesktopSettingsSwitch } from "./VesktopSettingsSwitch";
 import { WindowsTransparencyControls } from "./WindowsTransparencyControls";
+import { WebRTCIPHandlingPolicyPicker } from "renderer/components/settings/WebRTCIPHandlingPolicyPicker";
 
 interface BooleanSetting {
     key: keyof typeof Settings.store;
@@ -146,8 +147,11 @@ const SettingsOptions: Record<string, Array<BooleanSetting | SettingsComponent>>
             title: "Open Links in app (experimental)",
             description: "Opens links in a new Vesktop window instead of your web browser",
             defaultValue: false
-        }
+        },
+
+        WebRTCIPHandlingPolicyPicker
     ],
+
     "Developer Options": [DeveloperOptionsButton]
 };
 

--- a/src/renderer/components/settings/WebRTCIPHandlingPolicyPicker.tsx
+++ b/src/renderer/components/settings/WebRTCIPHandlingPolicyPicker.tsx
@@ -7,26 +7,36 @@
 import { Heading, Margins, Paragraph } from "@vencord/types/components";
 import { Select } from "@vencord/types/webpack/common";
 
+import { SimpleErrorBoundary } from "../SimpleErrorBoundary";
 import { SettingsComponent } from "./Settings";
 
 export const WebRTCIPHandlingPolicyPicker: SettingsComponent = ({ settings }) => {
     return (
-        <div>
-            <Heading tag="h5">WebRTC IP Handling Policy</Heading>
-            <Paragraph className={Margins.bottom8}>Specify the WebRTC IP handling policy.</Paragraph>
-            <Select
-                placeholder="Default"
-                options={[
-                    { label: "Default", value: "default", default: true },
-                    { label: "Default Public Interface Only", value: "default_public_interface_only" },
-                    { label: "Default Public And Private Interfaces", value: "default_public_and_private_interfaces" },
-                    { label: "Disable Non-Proxied UDP", value: "disable_non_proxied_udp" }
-                ]}
-                closeOnSelect={true}
-                select={v => (settings.webRTCIPHandlingPolicy = v)}
-                isSelected={v => v === settings.webRTCIPHandlingPolicy}
-                serialize={s => s}
-            />
-        </div>
+        <SimpleErrorBoundary>
+            <div>
+                <Heading tag="h5">WebRTC IP Handling Policy</Heading>
+                <Paragraph className={Margins.bottom8}>
+                    Changing this may help with voice connection issues on some networks, most notably VPNs like
+                    Tailscale.
+                </Paragraph>
+                <Select
+                    placeholder="Default"
+                    options={[
+                        { label: "Default", value: "default", default: true },
+                        { label: "Default Public Interface Only", value: "default_public_interface_only" },
+
+                        {
+                            label: "Default Public And Private Interfaces",
+                            value: "default_public_and_private_interfaces"
+                        },
+                        { label: "Disable Non-Proxied UDP", value: "disable_non_proxied_udp" }
+                    ]}
+                    closeOnSelect={true}
+                    select={v => (settings.webRTCIPHandlingPolicy = v)}
+                    isSelected={v => v === (settings.webRTCIPHandlingPolicy ?? "default")}
+                    serialize={s => s}
+                />
+            </div>
+        </SimpleErrorBoundary>
     );
 };

--- a/src/renderer/components/settings/WebRTCIPHandlingPolicyPicker.tsx
+++ b/src/renderer/components/settings/WebRTCIPHandlingPolicyPicker.tsx
@@ -1,0 +1,32 @@
+/*
+ * Vesktop, a desktop app aiming to give you a snappier Discord Experience
+ * Copyright (c) 2023 Vendicated and Vencord contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Heading, Margins, Paragraph } from "@vencord/types/components";
+import { Select } from "@vencord/types/webpack/common";
+
+import { SettingsComponent } from "./Settings";
+
+export const WebRTCIPHandlingPolicyPicker: SettingsComponent = ({ settings }) => {
+    return (
+        <div>
+            <Heading tag="h5">WebRTC IP Handling Policy</Heading>
+            <Paragraph className={Margins.bottom8}>Specify the WebRTC IP handling policy.</Paragraph>
+            <Select
+                placeholder="Default"
+                options={[
+                    { label: "Default", value: "default", default: true },
+                    { label: "Default Public Interface Only", value: "default_public_interface_only" },
+                    { label: "Default Public And Private Interfaces", value: "default_public_and_private_interfaces" },
+                    { label: "Disable Non-Proxied UDP", value: "disable_non_proxied_udp" }
+                ]}
+                closeOnSelect={true}
+                select={v => (settings.webRTCIPHandlingPolicy = v)}
+                isSelected={v => v === settings.webRTCIPHandlingPolicy}
+                serialize={s => s}
+            />
+        </div>
+    );
+};

--- a/src/shared/settings.d.ts
+++ b/src/shared/settings.d.ts
@@ -9,6 +9,11 @@ import type { Rectangle } from "electron";
 export interface Settings {
     discordBranch?: "stable" | "canary" | "ptb";
     transparencyOption?: "none" | "mica" | "tabbed" | "acrylic";
+    webRTCIPHandlingPolicy?:
+        | "default"
+        | "default_public_interface_only"
+        | "default_public_and_private_interfaces"
+        | "disable_non_proxied_udp";
     tray?: boolean;
     minimizeToTray?: boolean;
     autoStartMinimized?: boolean;


### PR DESCRIPTION
Builds on #1251:

- Adds  `webRTCIPHandlingPolicy` setting under Vesktop Settings.
- Adds an `app.on("web-contents-created", ...)` call in  `src/main/index.ts` to apply setting to all future windows.
- Adds a change listener for `webRTCIPHandlingPolicy` to apply setting to all current windows.


<img width="737" height="547" alt="Screenshot From 2026-07-10 17-57-24" src="https://github.com/user-attachments/assets/fd550a6b-1292-4f0f-942d-a56a69c2ee95" />