### PR TITLE
Fix broken screenshare on wayland

### DIFF
--- a/src/main/screenShare.ts
+++ b/src/main/screenShare.ts
@@ -48,17 +48,16 @@ export function registerScreenShareHandler() {
         }));
 
         if (isWayland) {
-            const video = data[0];
-            if (video) {
-                const stream = await sendRendererCommand<StreamPick>(IpcCommands.SCREEN_SHARE_PICKER, {
-                    screens: [video],
-                    skipPicker: true
-                }).catch(() => null);
+            const video = sources[0];
 
-                if (stream === null) return callback({});
+            if (!video) {
+                return callback({});
             }
 
-            callback(video ? { video: sources[0] } : {});
+            // On Wayland, xdg-desktop-portal has already handled source selection,
+            // so there is no need to show the renderer-side screen share picker.
+            // Just use the selected source directly.
+            callback({ video });
             return;
         }
 


### PR DESCRIPTION
The Problem

On Wayland, `desktopCapturer.getSources()` uses `xdg-desktop-portal` to show a native source selection dialog. After the user picks a screen/window in the portal, the portal closes and `getSources()` returns the selected source.

However, the original code then proceeded to call `sendRendererCommand(IpcCommands.SCREEN_SHARE_PICKER, ...)` with `skipPicker: true`, which opens a **second** modal in the renderer — the Vesktop `StreamSettingsUi` dialog. This caused some issues:

If the renderer modal crashes during rendering, the promise from `sendRendererCommand` rejects. The `.catch(() => null)` turns this into `null`, and `callback({})` is called — which makes Discord throw:
`   TypeError: Video was requested, but no video stream was provided`

This should fix #1247, possibly #1124 #753 