### PR TITLE
Add default audio source setting for linux screen sharing

### DIFF
--- a/src/renderer/components/ScreenSharePicker.tsx
+++ b/src/renderer/components/ScreenSharePicker.tsx
@@ -299,17 +299,6 @@ function AudioSettingsModal({
                     value={Settings.audio?.deviceSelect ?? false}
                     disabled={Settings.audio?.ignoreDevices}
                 />
-                <FormSwitch
-                    title="Default to Entire System Audio"
-                    description={
-                        <>
-                            Default to <b>Entire System</b> as audio source in the Screen Share Picker.
-                        </>
-                    }
-                    hideBorder
-                    onChange={v => (Settings.audio = { ...Settings.audio, defaultToEntireSystem: v })}
-                    value={Settings.audio?.defaultToEntireSystem ?? false}
-                />
             </div>
         </Modal>
     );
@@ -584,10 +573,28 @@ function AudioSourcePickerLinux({
     setIncludeSources: (s: AudioSources) => void;
     setExcludeSources: (s: AudioSources) => void;
 }) {
+    const persistIncludeSources = (s: AudioSources) => {
+        Settings.store.audio = { ...Settings.store.audio, lastSelectedSource: s };
+        setIncludeSources(s);
+    };
+
     const [audioSourcesSignal, refreshAudioSources] = useForceUpdater(true);
     const [sources, _, loading] = useAwaiter(() => VesktopNative.virtmic.list(), {
         fallbackValue: { ok: true, targets: [], hasPipewirePulse: true },
-        deps: [audioSourcesSignal]
+        deps: [audioSourcesSignal],
+        onSuccess(value) {
+            if (!value.ok || !Array.isArray(includeSources)) {
+                return;
+            }
+
+            const isAvailable = includeSources.every(selected =>
+                value.targets.some(target => hasMatchingProps(selected, target))
+            );
+
+            if (!isAvailable) {
+                persistIncludeSources("Entire System");
+            }
+        }
     });
 
     const hasPipewirePulse = sources.ok ? sources.hasPipewirePulse : true;
@@ -657,7 +664,7 @@ function AudioSourcePickerLinux({
                                 default: name === "None"
                             }))}
                             isSelected={isItemSelected(includeSources)}
-                            select={updateItems(setIncludeSources, includeSources)}
+                            select={updateItems(persistIncludeSources, includeSources)}
                             serialize={JSON.stringify}
                             popoutPosition="top"
                             closeOnSelect={false}
@@ -719,7 +726,7 @@ function ModalComponent({
     const [settings, setSettings] = useState<StreamSettings>({
         contentHint: "motion",
         audio: true,
-        includeSources: isLinux && Settings.store.audio?.defaultToEntireSystem ? "Entire System" : "None"
+        includeSources: isLinux ? (Settings.store.audio?.lastSelectedSource ?? "Entire System") : "None"
     });
     const qualitySettings = (useVesktopState().screenshareQuality ??= {
         resolution: "720",

--- a/src/renderer/components/ScreenSharePicker.tsx
+++ b/src/renderer/components/ScreenSharePicker.tsx
@@ -34,7 +34,7 @@ import {
 import { Node } from "@vencord/venmic";
 import type { Dispatch, SetStateAction } from "react";
 import { addPatch } from "renderer/patches/shared";
-import { State, useSettings, useVesktopState } from "renderer/settings";
+import { Settings, State, useSettings, useVesktopState } from "renderer/settings";
 import { isLinux, isWindows } from "renderer/utils";
 
 import { SimpleErrorBoundary } from "./SimpleErrorBoundary";
@@ -298,6 +298,17 @@ function AudioSettingsModal({
                     }}
                     value={Settings.audio?.deviceSelect ?? false}
                     disabled={Settings.audio?.ignoreDevices}
+                />
+                <FormSwitch
+                    title="Default to Entire System Audio"
+                    description={
+                        <>
+                            Default to <b>Entire System</b> as audio source in the Screen Share Picker.
+                        </>
+                    }
+                    hideBorder
+                    onChange={v => (Settings.audio = { ...Settings.audio, defaultToEntireSystem: v })}
+                    value={Settings.audio?.defaultToEntireSystem ?? false}
                 />
             </div>
         </Modal>
@@ -708,7 +719,7 @@ function ModalComponent({
     const [settings, setSettings] = useState<StreamSettings>({
         contentHint: "motion",
         audio: true,
-        includeSources: "None"
+        includeSources: isLinux && Settings.store.audio?.defaultToEntireSystem ? "Entire System" : "None"
     });
     const qualitySettings = (useVesktopState().screenshareQuality ??= {
         resolution: "720",

--- a/src/shared/settings.d.ts
+++ b/src/shared/settings.d.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
+import type { Node } from "@vencord/venmic";
 import type { Rectangle } from "electron";
 
 export interface Settings {
@@ -46,7 +47,7 @@ export interface Settings {
         deviceSelect?: boolean;
         granularSelect?: boolean;
 
-        defaultToEntireSystem?: boolean;
+        lastSelectedSource?: "None" | "Entire System" | Node[];
 
         ignoreVirtual?: boolean;
         ignoreDevices?: boolean;

--- a/src/shared/settings.d.ts
+++ b/src/shared/settings.d.ts
@@ -46,6 +46,8 @@ export interface Settings {
         deviceSelect?: boolean;
         granularSelect?: boolean;
 
+        defaultToEntireSystem?: boolean;
+
         ignoreVirtual?: boolean;
         ignoreDevices?: boolean;
         ignoreInputMedia?: boolean;


### PR DESCRIPTION
## Describe your Changes
- Implements [Allow users to select default audio source when streaming](https://github.com/Vencord/Vesktop/issues/1270) 
     - This implementation is only for linux users as "Entire System" uses [venmic](https://github.com/Vencord/Vesktop/blob/cb9c55fe1aa4cd1d3fbe23bddfdca02627c8c372/src/preload/VesktopNative.ts#L87).
- Added a boolean to the Audio Settings modal to default to entire system audio for screen sharing
- Read the above setting in the Screen Share Picker modal 
## Screenshots (if applicable)
- Manually verified that:
     -  when the `defaultToEntireSystem` toggle is enabled, "Entire System" audio source is automatically chosen.
     - when the `defaultToEntireSystem` toggle is disabled, "None" audio source is automatically chosen.
 -  Also ensured settings and behavior persist through application quit/startup. 
<img width="853" height="1140" alt="image" src="https://github.com/user-attachments/assets/b2ae03ff-5178-4e81-9951-42624819f56b" />

## Checklist before submitting
<!-- Hint: [x] this is how to check boxes -->
- [x] This pull request was written by me, and not an AI agent
